### PR TITLE
Improvements on manifests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "eclipxe/enum": "^0.2.0",
         "phpcfdi/credentials": "^1.0.1",
         "phpcfdi/xml-cancelacion": "^1.0.1",
-        "robrichards/xmlseclibs": "^3.0",
+        "robrichards/xmlseclibs": "^3.0.4",
         "eclipxe/micro-catalog": "^0.1.0",
         "phpcfdi/cfdi-expresiones": "^3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "phpcfdi/cfdi-expresiones": "^3.0"
     },
     "require-dev": {
+        "ext-fileinfo": "*",
         "eclipxe/cfdiutils": "^2.10",
         "phpunit/phpunit": "^8.4",
         "squizlabs/php_codesniffer": "^3.0",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,17 @@ Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor e
   no debe usar la opción de nulo, fue puesta para compatibilidad con versiones previas a `0.2.2`.
   No así el las fachadas `Finkok` y `QuickFinkok`.
 
+## Version 0.2.3 2019-11-05
+
+- El método `QuickFinkok::customerSignAndSendContracts` no estaba funcionando correctamente porque asumía
+  que el contenido de obtener los contratos estaba en texto plano, pero estaba codificado en `base64`.
+- La respuesta de obtener contratos automáticamente se decodifica de `base64` a texto plano.
+    - Esto afecta a los métodos `GetContractsResult::contract()` y `GetContractsResult::privacy()`
+- Se agrega el soporte del servicio para obtener el manifiesto previamente firmado a partir del SNID y el RFC.
+    - Servicio: `PhpCfdi\Finkok\Services\Manifest\GetSignedContractsService`
+    - Helper `QuickFinkok`: `QuickFinkok::customerGetSignedContracts()`
+    - Helper `Finkok`: `Finkok::getSignedContracts()`
+
 ## Version 0.2.2 2019-11-02
 
 - Se agrega el soporte del servicio que obtiene la hora de los servidores de Finkok usando un código postal.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,8 @@ Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor e
     - Servicio: `PhpCfdi\Finkok\Services\Manifest\GetSignedContractsService`
     - Helper `QuickFinkok`: `QuickFinkok::customerGetSignedContracts()`
     - Helper `Finkok`: `Finkok::getSignedContracts()`
+- Se actualiza `robrichards/xmlseclibs` a la versión 3.0.4 por el problema de seguridad CVE-2019-3465,
+  que aunque no se usa para este propósito se evita depender de esta versión.
 
 ## Version 0.2.2 2019-11-02
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,8 +2,6 @@
 
 - Los reportes que devuelven una cuenta deberían retornar un entero
 
-- Al usar get_contracts, decodificar el base64
-
 - La forma en que están hechos los objetos result es mezclada, algunas propiedades las obtiene cuando se solicitan
   y otras propiedades las obtiene en la creación del objeto. El problema es que se guarda la referencia al objeto
   stdClass de entrada, por lo que podría ser manipulado externamente y devolver resultados diferentes.

--- a/src/Definitions/SignedDocumentFormat.php
+++ b/src/Definitions/SignedDocumentFormat.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Definitions;
+
+use Eclipxe\Enum\Enum;
+
+/**
+ * @method static self xml()
+ * @method static self pdf()
+ * @method bool isXml()
+ * @method bool isPdf()
+ */
+class SignedDocumentFormat extends Enum
+{
+    protected static function overrideValues(): array
+    {
+        return [
+            'xml' => 'XML',
+            'pdf' => 'PDF',
+        ];
+    }
+}

--- a/src/Finkok.php
+++ b/src/Finkok.php
@@ -33,6 +33,7 @@ use PhpCfdi\Finkok\Services\Utilities;
  * @method Utilities\ReportUuidResult reportUuid(Utilities\ReportUuidCommand $command)
  * @method Manifest\GetContractsResult getContracts(Manifest\GetContractsCommand $command)
  * @method Manifest\SignContractsResult signContracts(Manifest\SignContractsCommand $command)
+ * @method Manifest\GetSignedContractsResult getSignedContracts(Manifest\GetSignedContractsCommand $command)
  * @method Registration\AddResult registrationAdd(Registration\AddCommand $command)
  * @method Registration\AssignResult registrationAssign(Registration\AssignCommand $command)
  * @method Registration\EditResult registrationEdit(Registration\EditCommand $command)
@@ -72,6 +73,10 @@ class Finkok
             Manifest\SignContractsService::class,
             Manifest\SignContractsCommand::class,
             'sendSignedContracts',
+        ],
+        'getSignedContracts' => [
+            Manifest\GetSignedContractsService::class,
+            Manifest\GetSignedContractsCommand::class,
         ],
     ];
 

--- a/src/QuickFinkok.php
+++ b/src/QuickFinkok.php
@@ -9,6 +9,7 @@ use PhpCfdi\Credentials\Credential;
 use PhpCfdi\Finkok\Definitions\CancelAnswer;
 use PhpCfdi\Finkok\Definitions\ReceiptType;
 use PhpCfdi\Finkok\Definitions\RfcRole;
+use PhpCfdi\Finkok\Definitions\SignedDocumentFormat;
 use PhpCfdi\Finkok\Services\Cancel;
 use PhpCfdi\Finkok\Services\Manifest;
 use PhpCfdi\Finkok\Services\Registration;
@@ -446,5 +447,24 @@ class QuickFinkok
         $privacy = (new Helpers\DocumentSigner($rfc, $signedOn, $documents->privacy()))->signUsingCredential($fiel);
         $contract = (new Helpers\DocumentSigner($rfc, $signedOn, $documents->contract()))->signUsingCredential($fiel);
         return $this->customerSendContracts($snid, $privacy, $contract);
+    }
+
+    /**
+     * Obtiene los documentos legales (aviso de privacidad y contrato) previamente firmados con el SNID y RFC
+     *
+     * @param string $snid
+     * @param string $rfc
+     * @param SignedDocumentFormat|null $format
+     * @return Manifest\GetSignedContractsResult
+     */
+    public function customerGetSignedContracts(
+        string $snid,
+        string $rfc,
+        SignedDocumentFormat $format = null
+    ): Manifest\GetSignedContractsResult {
+        $format = $format ?? SignedDocumentFormat::xml();
+        $command = new Manifest\GetSignedContractsCommand($snid, $rfc, $format);
+        $service = new Manifest\GetSignedContractsService($this->settings());
+        return $service->getSignedContracts($command);
     }
 }

--- a/src/Services/Manifest/GetContractsResult.php
+++ b/src/Services/Manifest/GetContractsResult.php
@@ -19,8 +19,8 @@ class GetContractsResult extends AbstractResult
         return new self((object) [
             'get_contractsResult' => (object) [
                 'success' => $success,
-                'contract' => $contract,
-                'privacy' => $privacy,
+                'contract' => base64_encode($contract),
+                'privacy' => base64_encode($privacy),
                 'error' => $error,
             ],
         ]);
@@ -33,12 +33,12 @@ class GetContractsResult extends AbstractResult
 
     public function contract(): string
     {
-        return strval($this->get('contract'));
+        return base64_decode(strval($this->get('contract')), true) ?: '';
     }
 
     public function privacy(): string
     {
-        return strval($this->get('privacy'));
+        return base64_decode(strval($this->get('privacy')), true) ?: '';
     }
 
     public function error(): string

--- a/src/Services/Manifest/GetSignedContractsCommand.php
+++ b/src/Services/Manifest/GetSignedContractsCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Services\Manifest;
+
+use PhpCfdi\Finkok\Definitions\SignedDocumentFormat;
+
+class GetSignedContractsCommand
+{
+    /** @var string */
+    private $snid;
+
+    /** @var string */
+    private $rfc;
+
+    /** @var SignedDocumentFormat */
+    private $format;
+
+    public function __construct(string $snid, string $rfc, SignedDocumentFormat $format)
+    {
+        $this->snid = $snid;
+        $this->rfc = $rfc;
+        $this->format = $format;
+    }
+
+    public function snid(): string
+    {
+        return $this->snid;
+    }
+
+    public function rfc(): string
+    {
+        return $this->rfc;
+    }
+
+    public function format(): SignedDocumentFormat
+    {
+        return $this->format;
+    }
+}

--- a/src/Services/Manifest/GetSignedContractsResult.php
+++ b/src/Services/Manifest/GetSignedContractsResult.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Services\Manifest;
+
+use PhpCfdi\Finkok\Services\AbstractResult;
+use stdClass;
+
+class GetSignedContractsResult extends AbstractResult
+{
+    /** @var bool */
+    private $success;
+
+    /** @var string */
+    private $contract;
+
+    /** @var string */
+    private $privacy;
+
+    /** @var string */
+    private $error;
+
+    public function __construct(stdClass $data, bool $isBase64)
+    {
+        parent::__construct($data, 'get_documentsResult');
+        $this->success = boolval($this->get('success'));
+        $this->contract = strval($this->get('contract'));
+        $this->privacy = strval($this->get('privacy'));
+        $this->error = strval($this->get('error'));
+        if ($isBase64) {
+            $this->contract = base64_decode($this->contract) ?: '';
+            $this->privacy = base64_decode($this->privacy) ?: '';
+        }
+    }
+
+    public function success(): bool
+    {
+        return $this->success;
+    }
+
+    public function contract(): string
+    {
+        return $this->contract;
+    }
+
+    public function privacy(): string
+    {
+        return $this->privacy;
+    }
+
+    public function error(): string
+    {
+        return $this->error;
+    }
+}

--- a/src/Services/Manifest/GetSignedContractsService.php
+++ b/src/Services/Manifest/GetSignedContractsService.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Services\Manifest;
+
+use PhpCfdi\Finkok\Definitions\Services;
+use PhpCfdi\Finkok\FinkokSettings;
+
+class GetSignedContractsService
+{
+    /** @var FinkokSettings */
+    private $settings;
+
+    public function __construct(FinkokSettings $settings)
+    {
+        $this->settings = $settings;
+    }
+
+    public function settings(): FinkokSettings
+    {
+        return $this->settings;
+    }
+
+    public function getSignedContracts(GetSignedContractsCommand $command): GetSignedContractsResult
+    {
+        // this empty string are for ommiting sending username and password
+        $soapCaller = $this->settings()->createCallerForService(Services::manifest(), '', '');
+        $rawResponse = $soapCaller->call('get_documents', [
+            'snid' => $command->snid(),
+            'taxpayer_id' => $command->rfc(),
+            'type' => $command->format()->value(),
+        ]);
+        return new GetSignedContractsResult($rawResponse, $command->format()->isPdf());
+    }
+}

--- a/tests/Integration/Services/Manifest/GetContractsServiceTest.php
+++ b/tests/Integration/Services/Manifest/GetContractsServiceTest.php
@@ -33,8 +33,8 @@ class GetContractsServiceTest extends IntegrationTestCase
         $this->assertNotEmpty($result->contract());
         $this->assertEmpty($result->error());
 
-        $privacy = strval(base64_decode($result->privacy()));
-        $contract = strval(base64_decode($result->contract()));
+        $privacy = $result->privacy();
+        $contract = $result->contract();
 
         $this->assertNotEmpty($privacy, 'Cannot decode privacy statement');
         $this->assertNotEmpty($contract, 'Cannot decode contract statement');

--- a/tests/Integration/Services/Manifest/GetDocumentsSignSendAndGetSignedTest.php
+++ b/tests/Integration/Services/Manifest/GetDocumentsSignSendAndGetSignedTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Integration\Services\Manifest;
+
+use PhpCfdi\Credentials\Credential;
+use PhpCfdi\Finkok\QuickFinkok;
+use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
+
+class GetDocumentsSignSendAndGetSignedTest extends IntegrationTestCase
+{
+    private function createFielCredential(): Credential
+    {
+        $certificateFile = $this->filePath('fiel/EKU9003173C9.cer.pem');
+        $privateKeyFile = $this->filePath('fiel/EKU9003173C9.key.pem');
+        $passPhrase = trim($this->fileContentPath('fiel/EKU9003173C9.password.bin'));
+        return Credential::openFiles($certificateFile, $privateKeyFile, $passPhrase);
+    }
+
+    public function testFullProcess(): void
+    {
+        $finkok = new QuickFinkok($this->createSettingsFromEnvironment());
+
+        $fiel = $this->createFielCredential();
+        $address = 'Cuauhtémoc #123, Colonia Centro, Villahermosa, Tabasco. CP 86000';
+        $email = 'legal@empresa-conocida.mx';
+        $snid = strval(getenv('FINKOK_SNID') ?? '');
+
+        $signedContracts = $finkok->customerSignAndSendContracts($fiel, $snid, $address, $email);
+        $this->assertTrue($signedContracts->success());
+
+        $currentContracts = $finkok->customerGetSignedContracts($snid, $fiel->rfc());
+        $this->assertTrue($currentContracts->success());
+    }
+}

--- a/tests/Integration/Services/Manifest/GetSignedContractsServiceTest.php
+++ b/tests/Integration/Services/Manifest/GetSignedContractsServiceTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Integration\Services\Manifest;
+
+use PhpCfdi\Finkok\Definitions\SignedDocumentFormat;
+use PhpCfdi\Finkok\Services\Manifest\GetSignedContractsCommand;
+use PhpCfdi\Finkok\Services\Manifest\GetSignedContractsService;
+use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
+
+class GetSignedContractsServiceTest extends IntegrationTestCase
+{
+    private function createService(): GetSignedContractsService
+    {
+        $settings = $this->createSettingsFromEnvironment();
+        return new GetSignedContractsService($settings);
+    }
+
+    public function providerGetSignedContracts(): array
+    {
+        return [
+            'xml' => [SignedDocumentFormat::xml(), 'text/xml'],
+            'pdf' => [SignedDocumentFormat::pdf(), 'application/pdf'],
+        ];
+    }
+
+    /**
+     * @param SignedDocumentFormat $format
+     * @param string $expectedMimeType
+     * @dataProvider providerGetSignedContracts
+     */
+    public function testGetSignedContracts(SignedDocumentFormat $format, string $expectedMimeType): void
+    {
+        $command = new GetSignedContractsCommand(
+            strval(getenv('FINKOK_SNID') ?? ''),
+            'EKU9003173C9',
+            $format
+        );
+
+        $service = $this->createService();
+        $result = $service->getSignedContracts($command);
+
+        $this->assertTrue($result->success());
+        $this->assertNotEmpty($result->privacy());
+        $this->assertNotEmpty($result->contract());
+        $this->assertEmpty($result->error());
+
+        $this->assertSame($expectedMimeType, $this->obtainMimeType($result->privacy()), 'Privacy invalid type');
+        $this->assertSame($expectedMimeType, $this->obtainMimeType($result->contract()), 'Contract invalid type');
+    }
+
+    private function obtainMimeType(string $contents): string
+    {
+        $temporary = tempnam('', '') ?: '';
+        if ('' === $temporary) {
+            return '';
+        }
+        try {
+            file_put_contents($temporary, $contents);
+            $type = mime_content_type($temporary) ?: '';
+        } finally {
+            unlink($temporary);
+        }
+        return $type;
+    }
+}

--- a/tests/Integration/Services/Manifest/SignContractsServiceTest.php
+++ b/tests/Integration/Services/Manifest/SignContractsServiceTest.php
@@ -33,8 +33,8 @@ class SignContractsServiceTest extends IntegrationTestCase
         $srvGetContracts = new GetContractsService($settings);
         $resGetContracts = $srvGetContracts->obtainContracts($cmdGetContracts);
 
-        $privacy = strval(base64_decode($resGetContracts->privacy()));
-        $contract = strval(base64_decode($resGetContracts->contract()));
+        $privacy = $resGetContracts->privacy();
+        $contract = $resGetContracts->contract();
 
         $signDate = new DateTimeImmutable('now');
         $privacyDocument = new DocumentSigner($rfc, $signDate, $privacy);

--- a/tests/Unit/Services/Manifest/GetSignedContractsCommandTest.php
+++ b/tests/Unit/Services/Manifest/GetSignedContractsCommandTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Unit\Services\Manifest;
+
+use PhpCfdi\Finkok\Definitions\SignedDocumentFormat;
+use PhpCfdi\Finkok\Services\Manifest\GetSignedContractsCommand;
+use PhpCfdi\Finkok\Tests\TestCase;
+
+class GetSignedContractsCommandTest extends TestCase
+{
+    public function testCreateCommand(): void
+    {
+        $formatXml = SignedDocumentFormat::xml();
+        $command = new GetSignedContractsCommand('x-snid', 'x-rfc', $formatXml);
+        $this->assertSame('x-snid', $command->snid());
+        $this->assertSame('x-rfc', $command->rfc());
+        $this->assertSame($formatXml, $command->format());
+    }
+}

--- a/tests/Unit/Services/Manifest/GetSignedContractsResultTest.php
+++ b/tests/Unit/Services/Manifest/GetSignedContractsResultTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Unit\Services\Manifest;
+
+use PhpCfdi\Finkok\Services\Manifest\GetSignedContractsResult;
+use PhpCfdi\Finkok\Tests\TestCase;
+
+class GetSignedContractsResultTest extends TestCase
+{
+    public function testResultUsingPredefinedResponses(): void
+    {
+        $data = json_decode($this->fileContentPath('manifest-getsignedcontracts-response.json'));
+        $result = new GetSignedContractsResult($data, false);
+        $this->assertTrue($result->success());
+        $this->assertSame('predefined-privacy', $result->privacy());
+        $this->assertSame('predefined-contract', $result->contract());
+        $this->assertSame('predefined-error', $result->error());
+    }
+}

--- a/tests/Unit/Services/Manifest/GetSignedContractsServiceTest.php
+++ b/tests/Unit/Services/Manifest/GetSignedContractsServiceTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Unit\Services\Manifest;
+
+use PhpCfdi\Finkok\Definitions\SignedDocumentFormat;
+use PhpCfdi\Finkok\Services\Manifest\GetSignedContractsCommand;
+use PhpCfdi\Finkok\Services\Manifest\GetSignedContractsService;
+use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
+use PhpCfdi\Finkok\Tests\TestCase;
+
+class GetSignedContractsServiceTest extends TestCase
+{
+    public function testServiceUsingPreparedResult(): void
+    {
+        $preparedResult = json_decode(TestCase::fileContentPath('manifest-getsignedcontracts-response.json'));
+
+        $soapFactory = new FakeSoapFactory();
+        $soapFactory->preparedResult = $preparedResult;
+
+        $settings = $this->createSettingsFromEnvironment($soapFactory);
+        $service = new GetSignedContractsService($settings);
+
+        $command = new GetSignedContractsCommand('x-snid', 'x-rfc', SignedDocumentFormat::xml());
+        $result = $service->getSignedContracts($command);
+        $this->assertSame('predefined-contract', $result->contract());
+
+        $caller = $soapFactory->latestSoapCaller;
+        $this->assertSame('get_documents', $caller->latestCallMethodName);
+        $this->assertArrayHasKey('snid', $caller->latestCallParameters);
+        $this->assertSame($command->snid(), $caller->latestCallParameters['snid']);
+        $this->assertArrayHasKey('taxpayer_id', $caller->latestCallParameters);
+        $this->assertSame($command->rfc(), $caller->latestCallParameters['taxpayer_id']);
+        $this->assertArrayHasKey('type', $caller->latestCallParameters);
+        $this->assertSame($command->format()->value(), $caller->latestCallParameters['type']);
+    }
+}

--- a/tests/_files/manifest-getcontracts-response.json
+++ b/tests/_files/manifest-getcontracts-response.json
@@ -1,8 +1,8 @@
 {
   "get_contractsResult": {
     "success": true,
-    "contract": "predefined-contract",
-    "privacy": "predefined-privacy",
+    "contract": "cHJlZGVmaW5lZC1jb250cmFjdA==",
+    "privacy": "cHJlZGVmaW5lZC1wcml2YWN5",
     "error": "predefined-error"
   }
 }

--- a/tests/_files/manifest-getsignedcontracts-response.json
+++ b/tests/_files/manifest-getsignedcontracts-response.json
@@ -1,0 +1,8 @@
+{
+  "get_documentsResult": {
+    "success": true,
+    "contract": "predefined-contract",
+    "privacy": "predefined-privacy",
+    "error": "predefined-error"
+  }
+}


### PR DESCRIPTION
- Fix method QuickFinkok::customerSignAndSendContracts() not working
- Implement QuickFinkok::customerGetSignedContracts() (Closes #12)
- GetContractsResult::contract() and GetContractsResult::privacy() are base64 decoded