### PR TITLE
Version 0.2.6

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -6,8 +6,9 @@ filter:
 # see https://scrutinizer-ci.com/docs/tools/php/php-scrutinizer/
 build:
   dependencies:
-    before:
+    override:
       - composer self-update --no-interaction --no-progress
+      - composer remove squizlabs/php_codesniffer friendsofphp/php-cs-fixer phpstan/phpstan --dev --no-interaction --no-progress --no-update
       - composer install --no-interaction
   nodes:
     php:

--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ Su cancelación es inmediata (al contrario de la solicitud de cancelación actua
 
 * `stamp(Retentions\StampCommand $command): Retentions\StampResult`
 
+Para descargar una retención debe usar el servicio `Utilerias`, método `get_xml` que está implementado previamente.
+Igualmente se ha creado el método `QuickFinkok::retentionDownload($uuid, $rfc)` para simplificar su implementación.
+
 ### Ayuda para firmado XML para SAT y Finkok
 
 Esta librería implementa el firmado CSD de los mensajes con el SAT para Cancelar, Obtener UUID relacionados

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Durante el proceso de implementación he creado diversas notas y documentos:
     - [X] Falta servicio que no requiera CSD/FIEL para aceptar o rechazar una solicitud de cancelación
     - [X] Falta servicio que no requiera CSD/FIEL para obtener los CFDI relacionados
     - [X] [El acuse de cancelación entregado al cancelar y al solicitar el acuse no coinciden](docs/issues/AcuseCancelacionNoCoincidente.md)
+    - [ ] [Error de cancelación de retenciones 1308 - Certificado revocado o caduco](docs/issues/CancelacionRetencionesError1308.md)
 
 ## Compatilibilidad
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,13 @@ respectivamente.
 * `getContracts(Manifest\GetContractsCommand $command): Manifest\GetContractsResult`
 * `signContracts(Manifest\SignContractsCommand $command): Manifest\SignContractsResult`
 
+### Retenciones
+
+Los CFDI de Retenciones e información de pagos (RET) siguen un estándar más parecido a CFDI 3.2.
+Su cancelación es inmediata (al contrario de la solicitud de cancelación actual).
+
+* `stamp(Retentions\StampCommand $command): Retentions\StampResult`
+
 ### Ayuda para firmado XML para SAT y Finkok
 
 Esta librería implementa el firmado CSD de los mensajes con el SAT para Cancelar, Obtener UUID relacionados

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [source]: https://github.com/phpcfdi/finkok
 [release]: https://github.com/phpcfdi/finkok/releases
 [license]: https://github.com/phpcfdi/finkok/blob/master/LICENSE
-[build]: https://travis-ci.org/phpcfdi/finkok?branch=master
+[build]: https://travis-ci.com/phpcfdi/finkok?branch=master
 [quality]: https://scrutinizer-ci.com/g/phpcfdi/finkok/
 [coverage]: https://scrutinizer-ci.com/g/phpcfdi/finkok/code-structure/master/code-coverage/src
 [downloads]: https://packagist.org/packages/phpcfdi/finkok
@@ -265,7 +265,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [badge-source]: https://img.shields.io/badge/source-phpcfdi/finkok-blue?style=flat-square
 [badge-release]: https://img.shields.io/github/release/phpcfdi/finkok?style=flat-square
 [badge-license]: https://img.shields.io/github/license/phpcfdi/finkok?style=flat-square
-[badge-build]: https://img.shields.io/travis/phpcfdi/finkok/master?style=flat-square
+[badge-build]: https://img.shields.io/travis/com/phpcfdi/finkok/master?style=flat-square
 [badge-quality]: https://img.shields.io/scrutinizer/g/phpcfdi/finkok/master?style=flat-square
 [badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/phpcfdi/finkok/master?style=flat-square
 [badge-downloads]: https://img.shields.io/packagist/dt/phpcfdi/finkok?style=flat-square

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Durante el proceso de implementación he creado diversas notas y documentos:
     - [X] [Consumir stamp para generar un doble estampado no devuelve los datos](docs/issues/StampServiceDobleEstampado.md)
     - [X] Falta servicio que no requiera CSD/FIEL para aceptar o rechazar una solicitud de cancelación
     - [X] Falta servicio que no requiera CSD/FIEL para obtener los CFDI relacionados
-    - [ ] El acuse de cancelación entregado al cancelar y al solicitar el acuse no coinciden.
+    - [X] [El acuse de cancelación entregado al cancelar y al solicitar el acuse no coinciden](docs/issues/AcuseCancelacionNoCoincidente.md)
 
 ## Compatilibilidad
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Los CFDI de Retenciones e información de pagos (RET) siguen un estándar más p
 Su cancelación es inmediata (al contrario de la solicitud de cancelación actual).
 
 * `stamp(Retentions\StampCommand $command): Retentions\StampResult`
+* `stamped(Retentions\StampedCommand $command): Retentions\StampedResult`
 
 Para descargar una retención debe usar el servicio `Utilerias`, método `get_xml` que está implementado previamente.
 Igualmente se ha creado el método `QuickFinkok::retentionDownload($uuid, $rfc)` para simplificar su implementación.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Su cancelación es inmediata (al contrario de la solicitud de cancelación actua
 
 * `stamp(Retentions\StampCommand $command): Retentions\StampResult`
 * `stamped(Retentions\StampedCommand $command): Retentions\StampedResult`
+* `cancelSignature(Retentions\CancelSignatureCommand $command): Retentions\StampedResult`
 
 Para descargar una retención debe usar el servicio `Utilerias`, método `get_xml` que está implementado previamente.
 Igualmente se ha creado el método `QuickFinkok::retentionDownload($uuid, $rfc)` para simplificar su implementación.

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "require-dev": {
         "ext-fileinfo": "*",
         "eclipxe/cfdiutils": "^2.10",
-        "phpunit/phpunit": "^8.4",
+        "phpunit/phpunit": "^8.5",
         "squizlabs/php_codesniffer": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.4",
         "phpstan/phpstan": "^0.12",

--- a/composer.json
+++ b/composer.json
@@ -38,12 +38,12 @@
     },
     "require-dev": {
         "ext-fileinfo": "*",
+        "symfony/dotenv": "^5.0",
         "eclipxe/cfdiutils": "^2.10",
         "phpunit/phpunit": "^8.5",
         "squizlabs/php_codesniffer": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.4",
-        "phpstan/phpstan": "^0.12",
-        "symfony/dotenv": "^5.0"
+        "phpstan/phpstan": "^0.12"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "psr/log": "^1.1",
         "eclipxe/enum": "^0.2.0",
         "phpcfdi/credentials": "^1.0.1",
-        "phpcfdi/xml-cancelacion": "^1.0.1",
+        "phpcfdi/xml-cancelacion": "^1.1.0",
         "robrichards/xmlseclibs": "^3.0.4",
         "eclipxe/micro-catalog": "^0.1.0",
         "phpcfdi/cfdi-expresiones": "^3.0"

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
             "vendor/bin/phpstan analyse --no-progress --verbose --level max src/ tests/"
         ],
         "dev:coverage": [
-            "@php -dzend_extension=xdebug.so vendor/bin/phpunit --coverage-text --coverage-html build/coverage/html/"
+            "@php -dzend_extension=xdebug.so vendor/bin/phpunit --verbose --coverage-html build/coverage/html/"
         ]
     },
     "scripts-descriptions": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor e
 - Se agrega el método `StampingAlert::extraInfo()` para obtener la respuesta de la incidencia en `ExtraInfo`.
 - Se agrega el método `StampingResult::faultCode()` para obtener la respuesta en `faultcode`.
 - Se renombra el método `StampingResult::faultstring()` a `StampingResult::faultString()`.
+- Se agrega el servicio de retenciones (para CFDI de retenciones e información de pagos).
 
 ## Version 0.2.5 2020-01-14
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,10 @@ Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor e
   no debe usar la opción de nulo, fue puesta para compatibilidad con versiones previas a `0.2.2`.
   No así el las fachadas `Finkok` y `QuickFinkok`.
 
+## Version UNRELEASED
+
+- Se agrega el método `StampingAlert::extraInfo()` para obtener la respuesta de la incidencia en `ExtraInfo`.
+
 ## Version 0.2.5 2020-01-14
 
 - Se actualiza el año de licencia 2020.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor e
 
 ## Version UNRELEASED
 
+- Documentar la solución del problema de acuse recibido al cancelar y al solicitar. Finkok ticket: `#41435`. 
 - Se agrega el método `StampingAlert::extraInfo()` para obtener la respuesta de la incidencia en `ExtraInfo`.
 - Se agrega el método `StampingResult::faultCode()` para obtener la respuesta en `faultcode`.
 - Se renombra el método `StampingResult::faultstring()` a `StampingResult::faultString()`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor e
 ## Version UNRELEASED
 
 - Se agrega el método `StampingAlert::extraInfo()` para obtener la respuesta de la incidencia en `ExtraInfo`.
+- Se agrega el método `StampingResult::faultCode()` para obtener la respuesta en `faultcode`.
 
 ## Version 0.2.5 2020-01-14
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,7 @@ Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor e
   no debe usar la opción de nulo, fue puesta para compatibilidad con versiones previas a `0.2.2`.
   No así el las fachadas `Finkok` y `QuickFinkok`.
 
-## Version UNRELEASED
+## Version 0.2.6 2020-01-24
 
 - Documentar la solución del problema de acuse recibido al cancelar y al solicitar. Finkok ticket: `#41435`. 
 - Se agrega el método `StampingAlert::extraInfo()` para obtener la respuesta de la incidencia en `ExtraInfo`.
@@ -22,6 +22,19 @@ Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor e
 - Se crean fábricas básicas de CFDI RET para poder testear.
 - Se agregan métodos de retenciones (comando, resultado, servicio y método en `QuickFinkok`):
     - Timbrado de retención: La respuesta tiene campos idénticos al timbrado de CFDI.
+    - Cancelación de retención: La respuesta tiene campos idénticos y adicionales al timbrado de CFDI.
+    - Para poder cancelar un RET, fue necesario actualizar a `phpcfdi/xml-cancelacion: ^1.1.0`.
+- El objeto `GetSatStatusExtractor` podía procesar CFDI 3.2, CFDI 3.3 y RET 1.0, sin embargo el método `get_sat_status`
+  sólo puede trabajar con CFDI 3.2, CFDI 3.3, se hacen las adecuaciones correspondientes.
+- Desarrollo:
+    - Se crearon pruebas unitarias para `QueryPendingCommand` y `QueryPendingResult`.
+    - Se reconstruye `createGetSatStatusCommandFromCfdiContents` para que use el helper `GetSatStatusExtractor`.
+    - Se mejoran las acciones `resetCustomerAccountToOnDemand` y `resetCustomerAccountToPrepaidWithZeroCredits`.
+    - Se actualiza de `phpstan/phpstan-shim: ^0.11` a `phpstan/phpstan: ^0.12`.
+    - Se actualiza a `phpunit/phpunit: ^8.5` porque el XSD de la versión previa no está disponible.
+    - Se crean nuevas tareas de desarrollo y mejora. 
+- Issues: A pesar de haber impementado la Cancelación de retención, el test de integración está fallando por un
+  error en el servicio de pruebas del SAT.
 
 ## Version 0.2.5 2020-01-14
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,8 @@ Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor e
 - Se renombra el método `StampingResult::faultstring()` a `StampingResult::faultString()`.
 - Se agrega el servicio de retenciones (para CFDI de retenciones e información de pagos).
 - Se crean fábricas básicas de CFDI RET para poder testear.
+- Se agregan métodos de retenciones (comando, resultado, servicio y método en `QuickFinkok`):
+    - Timbrado de retención: La respuesta tiene campos idénticos al timbrado de CFDI.
 
 ## Version 0.2.5 2020-01-14
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor e
 - Se agrega el método `StampingResult::faultCode()` para obtener la respuesta en `faultcode`.
 - Se renombra el método `StampingResult::faultstring()` a `StampingResult::faultString()`.
 - Se agrega el servicio de retenciones (para CFDI de retenciones e información de pagos).
+- Se crean fábricas básicas de CFDI RET para poder testear.
 
 ## Version 0.2.5 2020-01-14
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor e
 
 - Se agrega el método `StampingAlert::extraInfo()` para obtener la respuesta de la incidencia en `ExtraInfo`.
 - Se agrega el método `StampingResult::faultCode()` para obtener la respuesta en `faultcode`.
+- Se renombra el método `StampingResult::faultstring()` a `StampingResult::faultString()`.
 
 ## Version 0.2.5 2020-01-14
 

--- a/docs/Ejemplos/ConsultarEstadoCFDI.md
+++ b/docs/Ejemplos/ConsultarEstadoCFDI.md
@@ -1,0 +1,81 @@
+# Ejemplo de consulta de estado de un CFDI
+
+Para estos ejemplo partiremos de que tenemos un CFDI en el archivo `cfdi.xml`.
+Y que los datos son: RFC emisor `EKU9003173C9`, RFC receptor `JES900109Q90`,
+total `12345.67` y UUID `11111111-2222-3333-4444-000000000001`.
+
+Nota: El servicio `get_sat_status` solo puede obtener datos de CFDI 3.3 y CFDI 3.2.
+
+## Usando QuickFinkok con el CFDI
+
+Los datos de RFC emisor, receptor, total y UUID se obtienen directamente del CFDI.
+
+```php
+<?php
+declare(strict_types=1);
+
+use PhpCfdi\Finkok\FinkokEnvironment;
+use PhpCfdi\Finkok\FinkokSettings;
+use PhpCfdi\Finkok\QuickFinkok;
+
+$finkok = new QuickFinkok(new FinkokSettings('finkok-usuario', 'finkok-password', FinkokEnvironment::makeProduction()));
+$satStatus = $finkok->satStatusXml(file_get_contents(`cfdi.xml`));
+
+echo $satStatus->query();           // S - Comprobante obtenido satisfactoriamente.
+echo $satStatus->cfdi();            // Vigente
+echo $satStatus->cancellable();     // Cancelable sin aceptación 
+echo $satStatus->cancellation();    // (vacío) 
+```
+
+## Usando QuickFinkok con los datos
+
+```php
+<?php
+declare(strict_types=1);
+
+use PhpCfdi\Finkok\FinkokEnvironment;
+use PhpCfdi\Finkok\FinkokSettings;
+use PhpCfdi\Finkok\QuickFinkok;
+
+$rfcEmisor = 'EKU9003173C9';
+$rfcReceptor = 'JES900109Q90';
+$uuid = '11111111-2222-3333-4444-000000000001';
+$total = '12345.67';
+
+$finkok = new QuickFinkok(new FinkokSettings('finkok-usuario', 'finkok-password', FinkokEnvironment::makeProduction()));
+$satStatus = $finkok->satStatus($rfcEmisor, $rfcReceptor, $uuid, $total);
+
+echo $satStatus->query();           // S - Comprobante obtenido satisfactoriamente.
+echo $satStatus->cfdi();            // Vigente
+echo $satStatus->cancellable();     // Cancelable sin aceptación 
+echo $satStatus->cancellation();    // (vacío) 
+```
+
+## Usando Finkok
+
+La fachada `Finkok` es un poco más compleja de usar y funciona mejor si se está implementando un *command bus*.
+Para cualquier otro caso se recomienda usar `QuickFinkok`.
+
+```php
+<?php
+declare(strict_types=1);
+
+use PhpCfdi\Finkok\FinkokEnvironment;
+use PhpCfdi\Finkok\FinkokSettings;
+use PhpCfdi\Finkok\Finkok;
+use PhpCfdi\Finkok\Services\Cancel\GetSatStatusCommand;
+
+// datos de origen
+$rfcEmisor = 'EKU9003173C9';
+$rfcReceptor = 'JES900109Q90';
+$uuid = '11111111-2222-3333-4444-000000000001';
+$total = '12345.67';
+
+// comando
+$cmdGetSatStatus = new GetSatStatusCommand($rfcEmisor, $rfcReceptor, $uuid, $total);
+
+// ejecución del comando
+$finkok = new Finkok(new FinkokSettings('finkok-usuario', 'finkok-password', FinkokEnvironment::makeProduction()));
+$satStatus = $finkok->getSatStatus($cmdGetSatStatus);
+```
+

--- a/docs/ListadoDeServicios.md
+++ b/docs/ListadoDeServicios.md
@@ -1,3 +1,4 @@
+# Listado de servicios de Finkok
 
 ## Timbrado de CFDI
 
@@ -44,6 +45,7 @@ Servicios para trabajar cancelaciones con CFDI de otro PAC
 - [X] `add`: Agregar un cliente que va a timbrar bajo la cuenta de un socio de negocios de Finkok
 - [X] `edit`: Editar el estatus de un cliente, como lo es suspender o activar
 - [X] `get`: Listado o el status del RFC Emisor que este ingresando y tenga registrado en su cuenta
+- [X] `switch`: Cambia el tipo de cliente de prepago a ilimitado y viceversa
 
 ## Tokens
 
@@ -53,9 +55,11 @@ Servicios para trabajar cancelaciones con CFDI de otro PAC
 
 ## Retenciones
 
-- [ ] `Stamp`: Firma un CFDI RET, si fue firmado previamente retorna (a veces) el timbrado previo.
-- [ ] `Stamped`:  Regresa la información de un XML timbrado previamente.
-- [ ] `cancel_signature`: (implementado en entorno demo)
+Estos servicios son de CFDI de retenciones e información de pagos (RET).
+
+- [X] `stamp`: Firma un CFDI RET, si fue firmado previamente retorna el timbrado previo.
+- [ ] `stamped`:  Regresa la información de un XML timbrado previamente.
+- [ ] `cancel_signature`: Cancela un CFDI RET (el modelo de cancelación es el de CFDI 3.2).
 - [ ] `get_receipt`: Devuelve el acuse de recibo asociado a un UUID.
 
 ## Manifiesto de Finkok

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,6 +2,8 @@
 
 - Agregar la integración de CFDI de retenciones y pagos
 
+- Poder transformar un objeto de tipo `GetSatStatusResult` a `PhpCfdi\SatEstadoCfdi\CfdiStatus`.
+
 - Los reportes que devuelven una cuenta deberían retornar un entero
 
 - La forma en que están hechos los objetos result es mezclada, algunas propiedades las obtiene cuando se solicitan

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,8 +1,5 @@
 # phpcfdi/finkok To Do List
 
-- Revisar el estado del ticket https://support.finkok.com/support/tickets/41438 y modificar el test
-  `DownloadXmlServiceTest::testStampAndConsumeStampedImmediately`.
-
 - Revisar el estado del ticket https://support.finkok.com/support/tickets/41435 y modificar el test
   `CancelServicesTest::testCreateCfdiThenGetSatStatusThenCancelSignatureThenGetReceipt`.
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -28,6 +28,11 @@
   B hace la consulta de pendientes y ya no ve el UUID
   Se consulta el estado del UUID y está cancelado
 
+- Las pruebas de servicios no están verificando a dónde se está enviando la solicitud, por lo que podría existir un
+  error al crear el endpoint, el error saldría a la luz en pruebas de integración pero no en pruebas unitarias.
+  Se puede agregar un código como el siguiente (en `...\Tests\Unit\Services\Retentions\CancelSignatureServiceTest`):
+  `$this->assertStringEndsWith(Services::retentions()->value(), $soapFactory->latestWsdlLocation);`
+
 ## Documentación
 
 - Servicios:

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,5 +1,11 @@
 # phpcfdi/finkok To Do List
 
+- Investigar cómo validar firma en acuses y respuestas del SAT
+
+- Crear un namespace común porque hay clases que están interrelacionadas entre el estampado y cancelación
+  de cfdi y de retenciones. Así como las clases abstractas de colecciones y resultados.
+  Esto creará una incompatilidad con versiones previas.
+
 - Agregar la integración de CFDI de retenciones y pagos
 
 - Poder transformar un objeto de tipo `GetSatStatusResult` a `PhpCfdi\SatEstadoCfdi\CfdiStatus`.
@@ -37,6 +43,7 @@
 
 ## Documentación
 
+- Documentar los métodos de `QuickFinkok`
 - Servicios:
     - Servicios que reintentan por errores de Finkok
     - Parámetros added y coupon de registration add

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,8 +1,5 @@
 # phpcfdi/finkok To Do List
 
-- Revisar el estado del ticket https://support.finkok.com/support/tickets/41435 y modificar el test
-  `CancelServicesTest::testCreateCfdiThenGetSatStatusThenCancelSignatureThenGetReceipt`.
-
 - Agregar la integración de CFDI de retenciones y pagos
 
 - Los reportes que devuelven una cuenta deberían retornar un entero

--- a/docs/issues/AcuseCancelacionNoCoincidente.md
+++ b/docs/issues/AcuseCancelacionNoCoincidente.md
@@ -1,5 +1,7 @@
 # El acuse de cancelación no coincide
 
+> *Este error de encuenta solucionado*
+
 Cuando se realiza una cancelación (vía `cancel_signature`) una de las respuestas es el acuse de cancelación
 entregado por el SAT. Dicho *acuse* se puede consultar en la respuesta de cancelación como el *voucher*.
 
@@ -25,3 +27,10 @@ CFDI fuese cancelado, el acuse contiene solamente la respuesta a la petición pr
 2019-01-14: Se creó el ticket #41435 <https://support.finkok.com/support/tickets/41435> documentando esta situación
 y se publicará la actualización a pesar de este error, si Finkok decidiera no actualizar su servicio entonces
 se eliminará la comprobación en el test de integración.
+
+2019-01-15: Se confirmó que se sufría de un bug de carrera, cuando se solicita el acuse pero aun no ha sido almacenado
+entonces se devuelve un acuse "fabricado". El problema lo tenían al fabricarlo y esto ha sido corregido.
+Personalmente considero que, al tratarse de un documento "oficial" con firma XML, deberían evitar fabricarlo y mejor
+retornar un error de tipo "Acuse no disponible en este momento, intente más tarde".
+Sin embargo, hay que considerar la poca utilidad del acuse y que en realidad no es relevante,
+siempre que el acuse sea idéntico al retornado por el SAT entonces no debería considerarse un problema.

--- a/docs/issues/CancelacionRetencionesError1308.md
+++ b/docs/issues/CancelacionRetencionesError1308.md
@@ -1,0 +1,34 @@
+# Cancelacion de Retenciones con error 1308
+
+Al momento de hacer pruebas de integración sobre el servicio de cancelación de CFDI de tipo retenciones e información
+de pagos, se encuentra que al enviar la solicitud el servidor de pruebas del SAT responde  en `CodEstatus` el
+error `1308 - Certificado revocado o caduco`.
+
+Se ha reportado a Finkok con el [ticket #41610](https://support.finkok.com/support/tickets/41610) donde nos pudieron
+responder ciertos cuestionamientos pero el problema sigue sin resolverse:
+
+- ¿Hay algún RFC en especial que deba utilizar para poder hacer pruebas de CFDI de retenciones y pagos?
+
+Como tal no existe un RFC en especifico, ya que se pueden realizar con los RFCs que se encuentran actualmente
+disponible para realizar pruebas, sin embargo en este momento el SAT no esta respondiendo de manera satisfactoria
+al utilizar cualquiera de los RFCs que se tienen publicados en el wiki y que ellos mismos proporcionaron.
+
+- ¿Porqué está devolviendo el código 1308?
+
+Al parecer la incidencia se presenta por que el SAT no tiene habilitados los RFCs de prueba.
+
+- Si es un error del SAT, ¿se ha reportado?
+
+Sí, sin embargo no hemos obtenido una respuesta favorable de su parte y en estos momentos nos encontramos
+dando seguimiento al caso.
+
+- ¿Tienen ustedes pruebas de integración que confirmen que los servicios de pruebas del SAT están funcionando?
+En su momento cundo se implemento el método de cancelación de retenciones funcionaba de forma correcta sin embargo
+debido a la actualización de los certificados de pruebas ya no fue posible efectuar pruebas de manera satisfactoria.
+De nuestra parte también hemos efectuado pruebas sin embargo obtenemos la misma respuesta que usted obtiene.
+
+## Actualizaciones
+
+2020-01-24: Se encontró el problema y se obtuvo respuesta de las preguntas.
+
+2020-01-27: El problema persiste.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.4/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
          bootstrap="./tests/bootstrap.php" colors="true" cacheResult="false">
     <testsuites>
         <testsuite name="Default">

--- a/src/Definitions/Services.php
+++ b/src/Definitions/Services.php
@@ -12,12 +12,14 @@ use Eclipxe\Enum\Enum;
  * @method static self cancel()
  * @method static self manifest()
  * @method static self registration()
+ * @method static self retentions()
  *
  * @method bool isStamping()
  * @method bool isUtilities()
  * @method bool isCancel()
  * @method bool isManifest()
  * @method bool isRegistration()
+ * @method bool isRetentions()
  */
 class Services extends Enum
 {
@@ -29,6 +31,7 @@ class Services extends Enum
             'cancel' => '/servicios/soap/cancel.wsdl',
             'manifest' => '/servicios/soap/firmar.wsdl',
             'registration' => '/servicios/soap/registration.wsdl',
+            'retentions' => '/servicios/soap/retentions.wsdl',
         ];
     }
 }

--- a/src/Helpers/CancelSigner.php
+++ b/src/Helpers/CancelSigner.php
@@ -45,4 +45,10 @@ class CancelSigner
         $helper = new XmlCancelacionHelper(XmlCancelacionCredentials::createWithPhpCfdiCredential($credential));
         return $helper->signCancellationUuids($this->uuids(), $this->dateTime());
     }
+
+    public function signRetention(Credential $credential): string
+    {
+        $helper = new XmlCancelacionHelper(XmlCancelacionCredentials::createWithPhpCfdiCredential($credential));
+        return $helper->signRetentionCancellationUuids($this->uuids(), $this->dateTime());
+    }
 }

--- a/src/Helpers/DocumentSigner.php
+++ b/src/Helpers/DocumentSigner.php
@@ -54,7 +54,7 @@ class DocumentSigner
     {
         $document = $this->createDocumentToSign();
         $this->signDocumentUsingCredential($document, $credential);
-        return $document->saveXML();
+        return strval($document->saveXML());
     }
 
     public function createDocumentToSign(): DOMDocument

--- a/src/QuickFinkok.php
+++ b/src/QuickFinkok.php
@@ -525,4 +525,23 @@ class QuickFinkok
         $service = new Retentions\StampedService($this->settings());
         return $service->stamped($command);
     }
+
+    /**
+     * Este método es el encargado de cancelar un CFDIs de retenciones emitido por medio de los web services de Finkok
+     * Durante el proceso no se envía ningún CSD a Finkok y la solicitud firmada es creada usando los datos del CSD
+     *
+     * @param Credential $credential
+     * @param string $uuid
+     * @return Retentions\CancelSignatureResult
+     * @see https://wiki.finkok.com/doku.php?id=cancel_signature_method_retentions
+     * @see https://wiki.finkok.com/doku.php?id=cancel_method_retentions
+     */
+    public function retentionCancel(Credential $credential, string $uuid): Retentions\CancelSignatureResult
+    {
+        $signer = new Helpers\CancelSigner([$uuid]);
+        $signedRequest = $signer->signRetention($credential);
+        $command = new Retentions\CancelSignatureCommand($signedRequest);
+        $service = new Retentions\CancelSignatureService($this->settings());
+        return $service->cancelSignature($command);
+    }
 }

--- a/src/QuickFinkok.php
+++ b/src/QuickFinkok.php
@@ -85,7 +85,8 @@ class QuickFinkok
     }
 
     /**
-     * Obtiene el XML de un UUID timbrado en Finkok, solo es posible recuperar los timbrados en los últimos 3 meses
+     * Obtiene el XML de un UUID timbrado en Finkok de tipo CFDI 3.3
+     * solo es posible recuperar los timbrados en los últimos 3 meses.
      *
      * @param string $uuid
      * @param string $rfc
@@ -490,4 +491,21 @@ class QuickFinkok
         $service = new Retentions\StampService($this->settings());
         return $service->stamp($command);
     }
+
+    /**
+     * Obtiene el XML de un UUID timbrado en Finkok de tipo CFDI de retenciones e información de pagos
+     * solo es posible recuperar los timbrados en los últimos 3 meses.
+     *
+     * @param string $uuid
+     * @param string $rfc
+     * @return Utilities\DownloadXmlResult
+     * @see https://wiki.finkok.com/doku.php?id=get_xml
+     */
+    public function retentionDownload(string $uuid, string $rfc): Utilities\DownloadXmlResult
+    {
+        $command = new Utilities\DownloadXmlCommand($uuid, $rfc, 'R');
+        $service = new Utilities\DownloadXmlService($this->settings());
+        return $service->downloadXml($command);
+    }
+
 }

--- a/src/QuickFinkok.php
+++ b/src/QuickFinkok.php
@@ -13,6 +13,7 @@ use PhpCfdi\Finkok\Definitions\SignedDocumentFormat;
 use PhpCfdi\Finkok\Services\Cancel;
 use PhpCfdi\Finkok\Services\Manifest;
 use PhpCfdi\Finkok\Services\Registration;
+use PhpCfdi\Finkok\Services\Retentions;
 use PhpCfdi\Finkok\Services\Stamping;
 use PhpCfdi\Finkok\Services\Utilities;
 
@@ -481,5 +482,12 @@ class QuickFinkok
         $command = new Manifest\GetSignedContractsCommand($snid, $rfc, $format);
         $service = new Manifest\GetSignedContractsService($this->settings());
         return $service->getSignedContracts($command);
+    }
+
+    public function retentionStamp(string $xml): Retentions\StampResult
+    {
+        $command = new Retentions\StampCommand($xml);
+        $service = new Retentions\StampService($this->settings());
+        return $service->stamp($command);
     }
 }

--- a/src/QuickFinkok.php
+++ b/src/QuickFinkok.php
@@ -508,4 +508,21 @@ class QuickFinkok
         return $service->downloadXml($command);
     }
 
+    /**
+     * Este método regresa la información de un XML de retenciones e información de pagos ya timbrado previamente y
+     * que por algún motivo no se pudo recuperar en la primera petición que se realizó,
+     * con este método se puede recuperar el UUID y el XML timbrado
+     *
+     * Nota: el método no está documentado en Finkok
+     *
+     * @param string $preCfdi
+     * @return Retentions\StampedResult
+     * @see https://wiki.finkok.com/doku.php?id=retentions
+     */
+    public function retentionStamped(string $preCfdi): Retentions\StampedResult
+    {
+        $command = new Retentions\StampedCommand($preCfdi);
+        $service = new Retentions\StampedService($this->settings());
+        return $service->stamped($command);
+    }
 }

--- a/src/Services/Retentions/CancelSignatureCommand.php
+++ b/src/Services/Retentions/CancelSignatureCommand.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Services\Retentions;
+
+class CancelSignatureCommand extends \PhpCfdi\Finkok\Services\Cancel\CancelSignatureCommand
+{
+}

--- a/src/Services/Retentions/CancelSignatureResult.php
+++ b/src/Services/Retentions/CancelSignatureResult.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Services\Retentions;
+
+class CancelSignatureResult extends \PhpCfdi\Finkok\Services\Cancel\CancelSignatureResult
+{
+    /**
+     * @internal This property is not documented, see https://support.finkok.com/support/tickets/41498
+     * @return string
+     */
+    public function tracing(): string
+    {
+        return $this->get('SeguimientoCancelacion');
+    }
+}

--- a/src/Services/Retentions/CancelSignatureService.php
+++ b/src/Services/Retentions/CancelSignatureService.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Services\Retentions;
+
+use PhpCfdi\Finkok\Definitions\Services;
+use PhpCfdi\Finkok\FinkokSettings;
+
+class CancelSignatureService
+{
+    /** @var FinkokSettings */
+    private $settings;
+
+    public function __construct(FinkokSettings $settings)
+    {
+        $this->settings = $settings;
+    }
+
+    public function settings(): FinkokSettings
+    {
+        return $this->settings;
+    }
+
+    public function cancelSignature(CancelSignatureCommand $command): CancelSignatureResult
+    {
+        $soapCaller = $this->settings()->createCallerForService(Services::retentions());
+        $rawResponse = $soapCaller->call('cancel_signature', [
+            'xml' => $command->xml(),
+            'store_pending' => $command->storePending()->asBool(),
+        ]);
+        $result = new CancelSignatureResult($rawResponse);
+        return $result;
+    }
+}

--- a/src/Services/Retentions/StampCommand.php
+++ b/src/Services/Retentions/StampCommand.php
@@ -4,18 +4,8 @@ declare(strict_types=1);
 
 namespace PhpCfdi\Finkok\Services\Retentions;
 
-class StampCommand
+use PhpCfdi\Finkok\Services\Stamping\StampingCommand;
+
+class StampCommand extends StampingCommand
 {
-    /** @var string */
-    private $xml;
-
-    public function __construct(string $xml)
-    {
-        $this->xml = $xml;
-    }
-
-    public function xml(): string
-    {
-        return $this->xml;
-    }
 }

--- a/src/Services/Retentions/StampCommand.php
+++ b/src/Services/Retentions/StampCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Services\Retentions;
+
+class StampCommand
+{
+    /** @var string */
+    private $xml;
+
+    public function __construct(string $xml)
+    {
+        $this->xml = $xml;
+    }
+
+    public function xml(): string
+    {
+        return $this->xml;
+    }
+}

--- a/src/Services/Retentions/StampResult.php
+++ b/src/Services/Retentions/StampResult.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Services\Retentions;
+
+use PhpCfdi\Finkok\Services\Stamping\StampingResult;
+use stdClass;
+
+class StampResult extends StampingResult
+{
+    public function __construct(stdClass $data)
+    {
+        parent::__construct('stampResult', $data);
+    }
+}

--- a/src/Services/Retentions/StampService.php
+++ b/src/Services/Retentions/StampService.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Services\Retentions;
+
+use PhpCfdi\Finkok\Definitions\Services;
+use PhpCfdi\Finkok\FinkokSettings;
+
+class StampService
+{
+    /** @var FinkokSettings */
+    private $settings;
+
+    public function __construct(FinkokSettings $settings)
+    {
+        $this->settings = $settings;
+    }
+
+    public function settings(): FinkokSettings
+    {
+        return $this->settings;
+    }
+
+    public function stamp(StampCommand $command): StampResult
+    {
+        $soapCaller = $this->settings()->createCallerForService(Services::retentions());
+        $rawResponse = $soapCaller->call('stamp', [
+            'xml' => $command->xml(),
+        ]);
+        $result = new StampResult($rawResponse);
+        return $result;
+    }
+}

--- a/src/Services/Retentions/StampedCommand.php
+++ b/src/Services/Retentions/StampedCommand.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Services\Retentions;
+
+use PhpCfdi\Finkok\Services\Stamping\StampingCommand;
+
+class StampedCommand extends StampingCommand
+{
+}

--- a/src/Services/Retentions/StampedResult.php
+++ b/src/Services/Retentions/StampedResult.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Services\Retentions;
+
+use PhpCfdi\Finkok\Services\Stamping\StampingResult;
+use stdClass;
+
+class StampedResult extends StampingResult
+{
+    public function __construct(stdClass $data)
+    {
+        parent::__construct('stampedResult', $data);
+    }
+}

--- a/src/Services/Retentions/StampedService.php
+++ b/src/Services/Retentions/StampedService.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Services\Retentions;
+
+use PhpCfdi\Finkok\Definitions\Services;
+use PhpCfdi\Finkok\FinkokSettings;
+
+class StampedService
+{
+    /** @var FinkokSettings */
+    private $settings;
+
+    public function __construct(FinkokSettings $settings)
+    {
+        $this->settings = $settings;
+    }
+
+    public function settings(): FinkokSettings
+    {
+        return $this->settings;
+    }
+
+    public function stamped(StampedCommand $command): StampedResult
+    {
+        $soapCaller = $this->settings()->createCallerForService(Services::retentions());
+        $rawResponse = $soapCaller->call('stamped', [
+            'xml' => $command->xml(),
+        ]);
+        $result = new StampedResult($rawResponse);
+        return $result;
+    }
+}

--- a/src/Services/Stamping/StampingAlert.php
+++ b/src/Services/Stamping/StampingAlert.php
@@ -46,6 +46,11 @@ class StampingAlert
         return $this->get('MensajeIncidencia');
     }
 
+    public function extraInfo(): string
+    {
+        return $this->get('ExtraInfo');
+    }
+
     public function rfc(): string
     {
         return $this->get('RfcEmisor');

--- a/src/Services/Stamping/StampingResult.php
+++ b/src/Services/Stamping/StampingResult.php
@@ -34,6 +34,11 @@ class StampingResult extends AbstractResult
         return $this->get('faultstring');
     }
 
+    public function faultCode(): string
+    {
+        return $this->get('faultcode');
+    }
+
     public function date(): string
     {
         return $this->get('Fecha');

--- a/src/Services/Stamping/StampingResult.php
+++ b/src/Services/Stamping/StampingResult.php
@@ -29,7 +29,7 @@ class StampingResult extends AbstractResult
         return $this->get('UUID');
     }
 
-    public function faultstring(): string
+    public function faultString(): string
     {
         return $this->get('faultstring');
     }

--- a/tests/.env-example
+++ b/tests/.env-example
@@ -7,7 +7,7 @@ FINKOK_USERNAME="your.email@host.com"
 FINKOK_PASSWORD="the-secret-password"
 
 # integration account (something like SN99999999)
-FINKOK_SNID="SN03192650"
+FINKOK_SNID="SN99999999"
 
 # if enabled, will search for an RFC XDEL000101XX1 changing date until found one non existent to be created
 FINKOK_REGISTRATION_ADD_CREATE_RANDOM_RFC="1"

--- a/tests/Factories/PreCfdiRetentionCreatorHelper.php
+++ b/tests/Factories/PreCfdiRetentionCreatorHelper.php
@@ -7,6 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Factories;
 use CfdiUtils\Certificado\Certificado;
 use CfdiUtils\Elements\Dividendos10\Dividendos;
 use CfdiUtils\Elements\PagosAExtranjeros10\Pagosaextranjeros;
+use CfdiUtils\Nodes\NodeInterface;
 use CfdiUtils\Retenciones\RetencionesCreator10;
 use DateTimeImmutable;
 use DateTimeZone;
@@ -149,7 +150,7 @@ class PreCfdiRetentionCreatorHelper
 
     /**
      * @param array<string, string> $dividOUtil
-     * @return Dividendos
+     * @return Dividendos<NodeInterface>
      */
     public function createDividendosDividOUtil(array $dividOUtil = []): Dividendos
     {
@@ -171,7 +172,7 @@ class PreCfdiRetentionCreatorHelper
     /**
      * @param array<string, string> $pagosAExtranjeros
      * @param array<string, string> $noBeneficiario
-     * @return Pagosaextranjeros
+     * @return Pagosaextranjeros<NodeInterface>
      */
     public function createPagosAExtranjerosNoBeneficiario(
         array $pagosAExtranjeros = [],

--- a/tests/Factories/PreCfdiRetentionCreatorHelper.php
+++ b/tests/Factories/PreCfdiRetentionCreatorHelper.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Factories;
+
+use CfdiUtils\Certificado\Certificado;
+use CfdiUtils\Elements\Dividendos10\Dividendos;
+use CfdiUtils\Elements\PagosAExtranjeros10\Pagosaextranjeros;
+use CfdiUtils\Retenciones\RetencionesCreator10;
+use DateTimeImmutable;
+use DateTimeZone;
+
+class PreCfdiRetentionCreatorHelper
+{
+    /** @var Certificado */
+    private $certificate;
+
+    /** @var DateTimeImmutable */
+    private $invoiceDate;
+
+    /** @var string */
+    private $cveReten;
+
+    /** @var string */
+    private $emisorRfc;
+
+    /** @var string */
+    private $emisorName;
+
+    /** @var string */
+    private $cerFile;
+
+    /** @var string */
+    private $keyPemFile;
+
+    /** @var string */
+    private $passPhrase;
+
+    public function __construct(
+        string $cerFile,
+        string $keyPemFile,
+        string $passPhrase
+    ) {
+        $this->certificate = new Certificado($cerFile);
+        $this->emisorRfc = $this->certificate->getRfc();
+        $this->emisorName = $this->certificate->getName();
+        $this->cerFile = $cerFile;
+        $this->keyPemFile = $keyPemFile;
+        $this->passPhrase = $passPhrase;
+        $this->invoiceDate = new DateTimeImmutable('now -5 minutes', new DateTimeZone('America/Mexico_City'));
+    }
+
+    public function getInvoiceDate(): DateTimeImmutable
+    {
+        return $this->invoiceDate;
+    }
+
+    public function setInvoiceDate(DateTimeImmutable $invoiceDate): void
+    {
+        $this->invoiceDate = $invoiceDate;
+    }
+
+    public function getEmisorRfc(): string
+    {
+        return $this->emisorRfc;
+    }
+
+    public function setEmisorRfc(string $emisorRfc): void
+    {
+        $this->emisorRfc = $emisorRfc;
+    }
+
+    public function getEmisorName(): string
+    {
+        return $this->emisorName;
+    }
+
+    public function setEmisorName(string $emisorName): void
+    {
+        $this->emisorName = $emisorName;
+    }
+
+    public function getKeyPemFile(): string
+    {
+        return $this->keyPemFile;
+    }
+
+    public function getPassPhrase(): string
+    {
+        return $this->passPhrase;
+    }
+
+    public function getCertificate(): Certificado
+    {
+        return $this->certificate;
+    }
+
+    public function getCveReten(): string
+    {
+        return $this->cveReten;
+    }
+
+    public function setCveReten(string $cveReten): void
+    {
+        $this->cveReten = $cveReten;
+    }
+
+    public function createRetencionesCreator10(): RetencionesCreator10
+    {
+        $creator = new RetencionesCreator10();
+        $retenciones = $creator->retenciones();
+
+        $retenciones->addAttributes([
+            'FechaExp' => $this->getInvoiceDate()->format('c'),
+            'CveRetenc' => $this->getCveReten(),
+        ]);
+        $retenciones->addEmisor([
+            'RFCEmisor' => $this->getEmisorRfc(),
+            'NomDenRazSocE' => $this->getEmisorName(),
+        ]);
+        $retenciones->getReceptor()->addExtranjero([
+            'NumRegIdTrib' => '34100005800',
+            'NomDenRazSocR' => 'THE USA COMPANY, INC.',
+        ]);
+
+        $periodoEjercicio = intval($this->getInvoiceDate()->format('Y')) - 1;
+        $retenciones->addPeriodo([
+            'MesIni' => '1',
+            'MesFin' => '12',
+            'Ejerc' => $periodoEjercicio,
+        ]);
+
+        $retenciones->addTotales([
+            'montoTotOperacion' => '0',
+            'montoTotGrav' => '0',
+            'montoTotExent' => '0',
+            'montoTotRet' => '0',
+        ]);
+        return $creator;
+    }
+
+    public function signPrecfdi(RetencionesCreator10 $creator): string
+    {
+        $creator->putCertificado($this->getCertificate());
+        $creator->addSello('file://' . $this->getKeyPemFile(), $this->getPassPhrase());
+        return $creator->asXml();
+    }
+
+    /**
+     * @param array<string, string> $dividOUtil
+     * @return Dividendos
+     */
+    public function createDividendosDividOUtil(array $dividOUtil = []): Dividendos
+    {
+        $dividendos = new Dividendos();
+        $dividendos->addDividOUtil(array_merge([
+            'CveTipDivOUtil' => '06', // 06 - Proviene de CUFIN al 31 de diciembre 2013
+            'MontISRAcredRetMexico' => '0',
+            'MontISRAcredRetExtranjero' => '0',
+            'MontRetExtDivExt' => '0',
+            'TipoSocDistrDiv' => 'Sociedad Nacional',
+            'MontISRAcredNal' => '0',
+            'MontDivAcumNal' => '0',
+            'MontDivAcumExt' => '0',
+        ], $dividOUtil));
+
+        return $dividendos;
+    }
+
+    /**
+     * @param array<string, string> $pagosAExtranjeros
+     * @param array<string, string> $noBeneficiario
+     * @return Pagosaextranjeros
+     */
+    public function createPagosAExtranjerosNoBeneficiario(
+        array $pagosAExtranjeros = [],
+        array $noBeneficiario = []
+    ): Pagosaextranjeros {
+        $pagosAExtranjeros = new Pagosaextranjeros(array_merge([
+            'EsBenefEfectDelCobro' => 'NO',
+        ], $pagosAExtranjeros));
+        $pagosAExtranjeros->addNoBeneficiario(array_merge([
+            'PaisDeResidParaEfecFisc' => 'US',
+            'ConceptoPago' => '3', // 3 - Persona moral
+            'DescripcionConcepto' => 'Dividendos provenientes de CUFIN al 31 de Dic 2013',
+        ], $noBeneficiario));
+
+        return $pagosAExtranjeros;
+    }
+}

--- a/tests/Factories/RandomPreCfdiRetention.php
+++ b/tests/Factories/RandomPreCfdiRetention.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Factories;
+
+use DateTimeImmutable;
+use PhpCfdi\Finkok\Tests\TestCase;
+
+class RandomPreCfdiRetention
+{
+    public function createValid(): string
+    {
+        $amount = random_int(1000000, 10000000);
+        $helper = new PreCfdiRetentionCreatorHelper(
+            TestCase::filePath('certs/EKU9003173C9.cer'),
+            TestCase::filePath('certs/EKU9003173C9.key.pem'),
+            trim(TestCase::fileContentPath('certs/EKU9003173C9.password.bin'))
+        );
+        $helper->setCveReten('14');
+        $helper->setInvoiceDate(new DateTimeImmutable());
+
+        $creator = $helper->createRetencionesCreator10();
+        $retenciones = $creator->retenciones();
+        $retenciones->addPeriodo(['MesIni' => '5', 'MesFin' => '5']);
+        $retenciones->addTotales(['montoTotExent' => $amount, 'montoTotOperacion' => $amount]);
+        $retenciones->addImpRetenidos(
+            ['BaseRet' => '0', 'Impuesto' => '01', 'TipoPagoRet' => 'Pago provisional', 'montoRet' => '0']
+        );
+        $retenciones->addComplemento(
+            $helper->createDividendosDividOUtil([
+                'CveTipDivOUtil' => '06', // 06 - Proviene de CUFIN al 31 de diciembre 2013
+                'MontISRAcredRetMexico' => '0',
+                'MontISRAcredRetExtranjero' => '0',
+                'MontRetExtDivExt' => '0',
+                'TipoSocDistrDiv' => 'Sociedad Nacional',
+                'MontISRAcredNal' => '0',
+                'MontDivAcumNal' => '0',
+                'MontDivAcumExt' => '0',
+            ])
+        );
+
+        return $helper->signPrecfdi($creator);
+    }
+}

--- a/tests/Fakes/FakeSoapFactory.php
+++ b/tests/Fakes/FakeSoapFactory.php
@@ -14,6 +14,9 @@ class FakeSoapFactory extends SoapFactory
     /** @var FakeSoapCaller */
     public $latestSoapCaller;
 
+    /** @var string */
+    public $latestWsdlLocation;
+
     /** @var stdClass */
     public $preparedResult;
 
@@ -30,6 +33,7 @@ class FakeSoapFactory extends SoapFactory
         $soapCaller = new FakeSoapCaller($this->createSoapClient($wsdlLocation), $defaultOptions);
         $soapCaller->preparedResult = $this->preparedResult;
         $this->latestSoapCaller = $soapCaller;
+        $this->latestWsdlLocation = $wsdlLocation;
         return $soapCaller;
     }
 }

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace PhpCfdi\Finkok\Tests\Integration;
 
-use CfdiUtils\Cfdi;
 use DateTimeImmutable;
 use PhpCfdi\Finkok\Helpers\CancelSigner;
+use PhpCfdi\Finkok\Helpers\GetSatStatusExtractor;
 use PhpCfdi\Finkok\Services\Cancel\CancelSignatureCommand;
 use PhpCfdi\Finkok\Services\Cancel\GetSatStatusCommand;
 use PhpCfdi\Finkok\Services\Cancel\GetSatStatusResult;
@@ -74,13 +74,7 @@ abstract class IntegrationTestCase extends TestCase
 
     public function createGetSatStatusCommandFromCfdiContents(string $xmlContents): GetSatStatusCommand
     {
-        $cfdiReader = Cfdi::newFromString($xmlContents)->getQuickReader();
-        return new GetSatStatusCommand(
-            $cfdiReader->emisor['Rfc'],
-            $cfdiReader->receptor['Rfc'],
-            $cfdiReader->complemento->timbreFiscalDigital['uuid'],
-            $cfdiReader['total']
-        );
+        return GetSatStatusExtractor::fromXmlString($xmlContents)->buildCommand();
     }
 
     protected function createCancelSignatureCommandFromUuid(

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -21,8 +21,11 @@ use RuntimeException;
 
 abstract class IntegrationTestCase extends TestCase
 {
-    /** @var array<mixed> */
-    protected static $statics = [];
+    /** @var StampingResult|null */
+    protected static $staticCurrentStampingResult = null;
+
+    /** @var StampingCommand|null */
+    protected static $staticCurrentStampingCommand = null;
 
     public function newStampingCommand(): StampingCommand
     {
@@ -36,10 +39,10 @@ abstract class IntegrationTestCase extends TestCase
 
     public function currentStampingCommand(): StampingCommand
     {
-        if (! isset(static::$statics['stampingCommand'])) {
-            static::$statics['stampingCommand'] = $this->newStampingCommand();
+        if (null === static::$staticCurrentStampingCommand) {
+            static::$staticCurrentStampingCommand = $this->newStampingCommand();
         }
-        return static::$statics['stampingCommand'];
+        return static::$staticCurrentStampingCommand;
     }
 
     public function quickStamp(StampingCommand $stampingCommand): StampingResult
@@ -63,10 +66,10 @@ abstract class IntegrationTestCase extends TestCase
      */
     public function currentCfdi(): StampingResult
     {
-        if (! isset(static::$statics['cfdi'])) {
-            static::$statics['cfdi'] = $this->quickStamp($this->currentStampingCommand());
+        if (null === static::$staticCurrentStampingResult) {
+            static::$staticCurrentStampingResult = $this->quickStamp($this->currentStampingCommand());
         }
-        return static::$statics['cfdi'];
+        return static::$staticCurrentStampingResult;
     }
 
     public function createGetSatStatusCommandFromCfdiContents(string $xmlContents): GetSatStatusCommand

--- a/tests/Integration/Services/Cancel/CancelServicesTest.php
+++ b/tests/Integration/Services/Cancel/CancelServicesTest.php
@@ -50,8 +50,9 @@ class CancelServicesTest extends IntegrationTestCase
             }
             // do not try again if a SAT issue is **not** found
             // 708: Fink ok cannot connect to SAT
+            // 300: SAT authentication cancellation service fail
             // 205: SAT does not have the uuid available for cancellation
-            if ('708' !== $result->statusCode() && '205' !== $document->documentStatus()) {
+            if (! in_array($result->statusCode(), ['708', '300'], true) && '205' !== $document->documentStatus()) {
                 break;
             }
             // do not try again if in the loop for more than allowed

--- a/tests/Integration/Services/Cancel/CancelServicesTest.php
+++ b/tests/Integration/Services/Cancel/CancelServicesTest.php
@@ -29,7 +29,6 @@ class CancelServicesTest extends IntegrationTestCase
         $this->assertStringStartsWith('Cancelable ', $beforeCancelStatus->cancellable());
 
         // Create cancel signature command from capsule
-        $command = $this->createCancelSignatureCommandFromUuid($cfdi->uuid());
         $service = new CancelSignatureService($settings);
 
         // evaluate if known response was 205 or 708
@@ -37,6 +36,8 @@ class CancelServicesTest extends IntegrationTestCase
         // elapsed from stamping and cancelling is often more than 2 minutes
         $repeatUntil = strtotime('now +5 minutes');
         do {
+            // build command on every request
+            $command = $this->createCancelSignatureCommandFromUuid($cfdi->uuid());
             // perform cancel
             $result = $service->cancelSignature($command);
             $document = $result->documents()->first();

--- a/tests/Integration/Services/Cancel/CancelServicesTest.php
+++ b/tests/Integration/Services/Cancel/CancelServicesTest.php
@@ -42,10 +42,11 @@ class CancelServicesTest extends IntegrationTestCase
             $result = $service->cancelSignature($command);
             $document = $result->documents()->first();
             if ('300' === $result->statusCode()) {
-                $this->fail('StatusCode 300 was fixed by Finkok, ticket #17743');
+                // 300: SAT authentication cancellation service fail
+                $this->markTestSkipped('StatusCode 300: SAT authentication service fail. See tickets #17743 & #41594');
             }
             if ('304' === $result->statusCode()) {
-                $this->fail('StatusCode 304: "Certificado revocado o caduco", do you must change the CSD?');
+                $this->fail('StatusCode 304: Certificado revocado o caduco. Do you must change the CSD?');
             }
             // do not try again if a SAT issue is **not** found
             // 708: Fink ok cannot connect to SAT

--- a/tests/Integration/Services/Cancel/GetRelatedSignatureServiceTest.php
+++ b/tests/Integration/Services/Cancel/GetRelatedSignatureServiceTest.php
@@ -81,4 +81,29 @@ class GetRelatedSignatureServiceTest extends IntegrationTestCase
         $this->assertSame($first->uuid(), $result->children()->first()->uuid());
         $this->assertEmpty($result->error());
     }
+
+    /**
+     * Use this method to test specifics UUID, useful for debugging
+     * You have to fill the UUIDS, is expected that 2 relates to 1 and 3 relates to 2, as in previous test
+     *
+     * To enable this test you must add "@test" annotation
+     */
+    public function manualConsumeServiceWithRelated(): void
+    {
+        $first = '4F72BDE6-36FD-4D88-B740-78561BA9B6B3';
+        $second = '527002DF-49FB-4380-886F-5667900722AD';
+        $third = '2A403C20-1F8B-43E4-B15F-96E19CDB6760';
+
+        $command = $this->createGetRelatedSignatureCommand($second);
+        $service = $this->createService();
+        $result = $service->getRelatedSignature($command);
+
+        $this->assertNotEmpty($result->parents()->first()->uuid(), 'Did not receive the parent UUID');
+        $this->assertSame($third, $result->parents()->first()->uuid());
+
+        $this->assertNotEmpty($result->children()->first()->uuid(), 'Did not receive the child UUID');
+        $this->assertSame($first, $result->children()->first()->uuid());
+
+        $this->assertEmpty($result->error(), 'The result must not contain any error');
+    }
 }

--- a/tests/Integration/Services/Registration/AssignServiceTest.php
+++ b/tests/Integration/Services/Registration/AssignServiceTest.php
@@ -37,7 +37,9 @@ class AssignServiceTest extends RegistrationIntegrationTestCase
                 $switchService->switch(new SwitchCommand($rfc, CustomerType::ondemand()))->success(),
                 'Unable to change the customer type to on-demand'
             );
+            $customer = $this->findCustomerOrFail($rfc);
         }
+        $this->assertTrue($customer->customerType()->isOndemand());
     }
 
     public function resetCustomerAccountToPrepaidWithZeroCredits(): void

--- a/tests/Integration/Services/Registration/AssignServiceTest.php
+++ b/tests/Integration/Services/Registration/AssignServiceTest.php
@@ -52,14 +52,19 @@ class AssignServiceTest extends RegistrationIntegrationTestCase
                 $switchService->switch(new SwitchCommand($rfc, CustomerType::prepaid()))->success(),
                 'Unable to change the customer type to prepaid'
             );
+            $customer = $this->findCustomerOrFail($rfc);
         }
+        $this->assertTrue($customer->customerType()->isPrepaid());
+
         // set credits to zero.
         if ($customer->credit() > 0) {
             $this->assertTrue(
                 $service->assign(new AssignCommand($rfc, -1 * $customer->credit()))->success(),
                 'Unable to set current credits to zero'
             );
+            $customer = $this->findCustomerOrFail($rfc);
         }
+        $this->assertSame(0, $customer->credit());
     }
 
     public function testAssignServiceToPrepaidAccount(): void

--- a/tests/Integration/Services/Retentions/CancelSignatureServiceTest.php
+++ b/tests/Integration/Services/Retentions/CancelSignatureServiceTest.php
@@ -36,8 +36,8 @@ final class CancelSignatureServiceTest extends RetentionsTestCase
             throw new RuntimeException('Cannot create a CFDI RET to cancel');
         }
         $result = $this->quickFinkok->retentionCancel($this->createCsdCredential(), $uuid);
-        if ('1308' === $result->statusCode()) {
-            $this->markTestSkipped('SAT service error, finkok ticket #41610');
+        if ('1308' === $result->statusCode()) { // 1308 - Certificado revocado o caduco
+            $this->markTestSkipped("SAT service error, finkok ticket #41610, RET UUID $uuid");
         }
 
         $this->assertNotEmpty($result->voucher(), 'Expected to receive an Acuse, but it was empty');
@@ -55,6 +55,9 @@ final class CancelSignatureServiceTest extends RetentionsTestCase
         $uuid = 'AAB81A24-8CD8-4703-A2CE-88F4E98E8044';
         $result = $this->quickFinkok->retentionCancel($this->createCsdCredential(), $uuid);
         echo json_encode($result->rawData(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if ('1308' === $result->statusCode()) {
+            $this->markTestSkipped('Finkok ticket #41610, SAT error: Certificado revocado o caduco');
+        }
         $this->assertSame($uuid, $result->documents()->first()->uuid(), 'Cancelled UUID must match with requested');
     }
 }

--- a/tests/Integration/Services/Retentions/CancelSignatureServiceTest.php
+++ b/tests/Integration/Services/Retentions/CancelSignatureServiceTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Integration\Services\Retentions;
+
+use PhpCfdi\Finkok\QuickFinkok;
+use RuntimeException;
+
+/**
+ * This class uses QuickFinkok to simplify calls.
+ */
+final class CancelSignatureServiceTest extends RetentionsTestCase
+{
+    /** @var QuickFinkok */
+    private $quickFinkok;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->quickFinkok = new QuickFinkok($this->createSettingsFromEnvironment());
+    }
+
+    public function testCancelSignatureWithNonExistentUUID(): void
+    {
+        $uuid = '11111111-2222-3333-4444-000000000001';
+        $result = $this->quickFinkok->retentionCancel($this->createCsdCredential(), $uuid);
+        $this->assertSame('UUID Not Found', $result->statusCode());
+    }
+
+    public function testCancelSignatureRecentlyCreatedDocument(): void
+    {
+        $stampedToCancel = $this->quickFinkok->retentionStamp($this->newRetentionsPreCfdi());
+        $uuid = $stampedToCancel->uuid();
+        if ('' === $uuid) {
+            throw new RuntimeException('Cannot create a CFDI RET to cancel');
+        }
+        $result = $this->quickFinkok->retentionCancel($this->createCsdCredential(), $uuid);
+        if ('1308' === $result->statusCode()) {
+            $this->markTestSkipped('SAT service error, finkok ticket #41610');
+        }
+
+        $this->assertNotEmpty($result->voucher(), 'Expected to receive an Acuse, but it was empty');
+        $this->assertSame('1201', $result->statusCode());
+        $this->assertSame($uuid, $result->documents()->first()->uuid());
+    }
+
+    /**
+     * Use this method to test cancellation on one specific UUID, useful for debugging
+     *
+     * To enable this test you must add "@test" annotation
+     */
+    public function manualCancelSignatureRecentlyCreatedDocument(): void
+    {
+        $uuid = 'AAB81A24-8CD8-4703-A2CE-88F4E98E8044';
+        $result = $this->quickFinkok->retentionCancel($this->createCsdCredential(), $uuid);
+        echo json_encode($result->rawData(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $this->assertSame($uuid, $result->documents()->first()->uuid(), 'Cancelled UUID must match with requested');
+    }
+}

--- a/tests/Integration/Services/Retentions/RetentionsTestCase.php
+++ b/tests/Integration/Services/Retentions/RetentionsTestCase.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Integration\Services\Retentions;
+
+use PhpCfdi\Finkok\Services\Retentions\StampCommand;
+use PhpCfdi\Finkok\Services\Retentions\StampResult;
+use PhpCfdi\Finkok\Tests\Factories\RandomPreCfdiRetention;
+use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
+
+abstract class RetentionsTestCase extends IntegrationTestCase
+{
+    /** @var string|null */
+    protected static $staticCurrentStampPrecfdi;
+
+    /** @var StampResult|null */
+    protected static $staticCurrentStampResult;
+
+    protected function currentRetentionsPreCfdi(): string
+    {
+        if (null === static::$staticCurrentStampPrecfdi) {
+            static::$staticCurrentStampPrecfdi = $this->newRetentionsPreCfdi();
+        }
+        return static::$staticCurrentStampPrecfdi;
+    }
+
+    protected function currentRetentionsStampResult(): StampResult
+    {
+        if (null === static::$staticCurrentStampResult) {
+            static::$staticCurrentStampResult = $this->stampRetentionPreCfdi($this->currentRetentionsPreCfdi());
+        }
+        return static::$staticCurrentStampResult;
+    }
+
+    protected function newRetentionsPreCfdi(): string
+    {
+        return (new RandomPreCfdiRetention())->createValid();
+    }
+
+    protected function stampRetentionPreCfdi(string $precfdi): StampResult
+    {
+        $command = new StampCommand($precfdi);
+        $service = $this->createService();
+        return $service->stamp($command);
+    }
+}

--- a/tests/Integration/Services/Retentions/RetentionsTestCase.php
+++ b/tests/Integration/Services/Retentions/RetentionsTestCase.php
@@ -12,28 +12,6 @@ use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
 abstract class RetentionsTestCase extends IntegrationTestCase
 {
-    /** @var string|null */
-    protected static $staticCurrentStampPrecfdi;
-
-    /** @var StampResult|null */
-    protected static $staticCurrentStampResult;
-
-    protected function currentRetentionsPreCfdi(): string
-    {
-        if (null === static::$staticCurrentStampPrecfdi) {
-            static::$staticCurrentStampPrecfdi = $this->newRetentionsPreCfdi();
-        }
-        return static::$staticCurrentStampPrecfdi;
-    }
-
-    protected function currentRetentionsStampResult(): StampResult
-    {
-        if (null === static::$staticCurrentStampResult) {
-            static::$staticCurrentStampResult = $this->stampRetentionPreCfdi($this->currentRetentionsPreCfdi());
-        }
-        return static::$staticCurrentStampResult;
-    }
-
     protected function newRetentionsPreCfdi(): string
     {
         return (new RandomPreCfdiRetention())->createValid();

--- a/tests/Integration/Services/Retentions/RetentionsTestCase.php
+++ b/tests/Integration/Services/Retentions/RetentionsTestCase.php
@@ -6,6 +6,7 @@ namespace PhpCfdi\Finkok\Tests\Integration\Services\Retentions;
 
 use PhpCfdi\Finkok\Services\Retentions\StampCommand;
 use PhpCfdi\Finkok\Services\Retentions\StampResult;
+use PhpCfdi\Finkok\Services\Retentions\StampService;
 use PhpCfdi\Finkok\Tests\Factories\RandomPreCfdiRetention;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
@@ -38,10 +39,15 @@ abstract class RetentionsTestCase extends IntegrationTestCase
         return (new RandomPreCfdiRetention())->createValid();
     }
 
+    protected function createStampService(): StampService
+    {
+        return new StampService($this->createSettingsFromEnvironment());
+    }
+
     protected function stampRetentionPreCfdi(string $precfdi): StampResult
     {
         $command = new StampCommand($precfdi);
-        $service = $this->createService();
+        $service = $this->createStampService();
         return $service->stamp($command);
     }
 }

--- a/tests/Integration/Services/Retentions/RetentionsUsingExistentRetentionTest.php
+++ b/tests/Integration/Services/Retentions/RetentionsUsingExistentRetentionTest.php
@@ -97,11 +97,4 @@ final class RetentionsUsingExistentRetentionTest extends RetentionsTestCase
             'Created and downloaded RET must be identical'
         );
     }
-
-    public function testObtainSatStatus(): void
-    {
-        $currentResult = $this->currentRetentionsStampResult();
-        $status = $this->quickFinkok->satStatusXml($currentResult->xml());
-        $this->assertStringStartsWith('S - ', $status->cfdi());
-    }
 }

--- a/tests/Integration/Services/Retentions/RetentionsUsingExistentRetentionTest.php
+++ b/tests/Integration/Services/Retentions/RetentionsUsingExistentRetentionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpCfdi\Finkok\Tests\Integration\Services\Retentions;
 
 use PhpCfdi\Finkok\QuickFinkok;
+use PhpCfdi\Finkok\Services\Retentions\StampResult;
 
 /**
  * This class uses a currently signed cfdi to perform test that require this to exists
@@ -14,6 +15,28 @@ final class RetentionsUsingExistentRetentionTest extends RetentionsTestCase
 {
     /** @var QuickFinkok */
     private $quickFinkok;
+
+    /** @var string|null */
+    protected static $staticCurrentStampPrecfdi;
+
+    /** @var StampResult|null */
+    protected static $staticCurrentStampResult;
+
+    protected function currentRetentionsPreCfdi(): string
+    {
+        if (null === static::$staticCurrentStampPrecfdi) {
+            static::$staticCurrentStampPrecfdi = $this->newRetentionsPreCfdi();
+        }
+        return static::$staticCurrentStampPrecfdi;
+    }
+
+    protected function currentRetentionsStampResult(): StampResult
+    {
+        if (null === static::$staticCurrentStampResult) {
+            static::$staticCurrentStampResult = $this->stampRetentionPreCfdi($this->currentRetentionsPreCfdi());
+        }
+        return static::$staticCurrentStampResult;
+    }
 
     protected function setUp(): void
     {
@@ -73,5 +96,12 @@ final class RetentionsUsingExistentRetentionTest extends RetentionsTestCase
             $downloadResult->xml(),
             'Created and downloaded RET must be identical'
         );
+    }
+
+    public function testObtainSatStatus(): void
+    {
+        $currentResult = $this->currentRetentionsStampResult();
+        $status = $this->quickFinkok->satStatusXml($currentResult->xml());
+        $this->assertStringStartsWith('S - ', $status->cfdi());
     }
 }

--- a/tests/Integration/Services/Retentions/RetentionsUsingExistentRetentionTest.php
+++ b/tests/Integration/Services/Retentions/RetentionsUsingExistentRetentionTest.php
@@ -25,6 +25,18 @@ final class RetentionsUsingExistentRetentionTest extends RetentionsTestCase
         );
     }
 
+    public function testStampValidPreCfdiRetentionsTwice(): void
+    {
+        $currentResult = $this->currentRetentionsStampResult();
+        $preCfdi = $this->currentRetentionsPreCfdi(); // this is the same precfdi used on currentStampResult
+
+        $repeatedResult = $this->quickFinkok->retentionStamp($preCfdi);
+
+        $this->assertSame($currentResult->uuid(), $repeatedResult->uuid(), 'UUID on first and second stamp must match');
+        $this->assertSame('Comprobante timbrado previamente', $repeatedResult->statusCode());
+        $this->assertSame('El CFDI contiene un timbre previo', $repeatedResult->alerts()->first()->message());
+    }
+
     public function testStamped(): void
     {
         $currentResult = $this->currentRetentionsStampResult();
@@ -32,6 +44,24 @@ final class RetentionsUsingExistentRetentionTest extends RetentionsTestCase
 
         // consume quickfinkok to simplify the execution
         $downloadResult = $this->quickFinkok->retentionStamped($preCfdi);
+
+        $this->assertXmlStringEqualsXmlString(
+            $currentResult->xml(),
+            $downloadResult->xml(),
+            'Created and downloaded RET must be XML equal'
+        );
+        $this->assertSame(
+            $currentResult->xml(),
+            $downloadResult->xml(),
+            'Created and downloaded RET must be identical'
+        );
+    }
+
+    public function testDownloadRetentionRecentlyCreated(): void
+    {
+        $currentResult = $this->currentRetentionsStampResult();
+
+        $downloadResult = $this->quickFinkok->retentionDownload($currentResult->uuid(), 'EKU9003173C9');
 
         $this->assertXmlStringEqualsXmlString(
             $currentResult->xml(),

--- a/tests/Integration/Services/Retentions/RetentionsUsingExistentRetentionTest.php
+++ b/tests/Integration/Services/Retentions/RetentionsUsingExistentRetentionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Integration\Services\Retentions;
+
+use PhpCfdi\Finkok\QuickFinkok;
+
+/**
+ * This class uses a currently signed cfdi to perform test that require this to exists
+ * It uses QuickFinkok to simplify calls.
+ */
+final class RetentionsUsingExistentRetentionTest extends RetentionsTestCase
+{
+    /** @var QuickFinkok */
+    private $quickFinkok;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->quickFinkok = new QuickFinkok($this->createSettingsFromEnvironment());
+        $this->assertNotEmpty(
+            $this->currentRetentionsStampResult()->uuid(),
+            'To run this test there must be an already stamped retention precfdi'
+        );
+    }
+
+    public function testStamped(): void
+    {
+        $currentResult = $this->currentRetentionsStampResult();
+        $preCfdi = $this->currentRetentionsPreCfdi(); // this is the same precfdi used on currentStampResult
+
+        // consume quickfinkok to simplify the execution
+        $downloadResult = $this->quickFinkok->retentionStamped($preCfdi);
+
+        $this->assertXmlStringEqualsXmlString(
+            $currentResult->xml(),
+            $downloadResult->xml(),
+            'Created and downloaded RET must be XML equal'
+        );
+        $this->assertSame(
+            $currentResult->xml(),
+            $downloadResult->xml(),
+            'Created and downloaded RET must be identical'
+        );
+    }
+}

--- a/tests/Integration/Services/Retentions/StampServiceTest.php
+++ b/tests/Integration/Services/Retentions/StampServiceTest.php
@@ -4,18 +4,8 @@ declare(strict_types=1);
 
 namespace PhpCfdi\Finkok\Tests\Integration\Services\Retentions;
 
-use PhpCfdi\Finkok\QuickFinkok;
-
 final class StampServiceTest extends RetentionsTestCase
 {
-    public function testStampInvalidXml(): void
-    {
-        $result = $this->stampRetentionPreCfdi('invalid xml');
-        $this->assertEmpty($result->xml());
-        $this->assertEmpty($result->uuid());
-        $this->assertTrue($result->hasAlerts());
-    }
-
     public function testStampValidPreCfdiRetentions(): void
     {
         $result = $this->currentRetentionsStampResult();
@@ -25,37 +15,11 @@ final class StampServiceTest extends RetentionsTestCase
         $this->assertNotEmpty($result->seal());
     }
 
-    public function testStampValidPreCfdiRetentionsTwice(): void
+    public function testStampInvalidXml(): void
     {
-        $currentResult = $this->currentRetentionsStampResult();
-        $this->assertNotEmpty($currentResult->uuid(), 'There must be an already stamped precfdi');
-
-        $preCfdi = $this->currentRetentionsPreCfdi(); // this is the same precfdi used on currentStampResult
-        $repeatedResult = $this->stampRetentionPreCfdi($preCfdi);
-
-        $this->assertSame($currentResult->uuid(), $repeatedResult->uuid(), 'UUID on first and second stamp must match');
-        $this->assertSame('Comprobante timbrado previamente', $repeatedResult->statusCode());
-        $this->assertSame('El CFDI contiene un timbre previo', $repeatedResult->alerts()->first()->message());
-    }
-
-    public function testDownloadRetentionRecentlyCreated(): void
-    {
-        $currentResult = $this->currentRetentionsStampResult();
-        $this->assertNotEmpty($currentResult->uuid(), 'There must be an already stamped precfdi');
-
-        // consume quickfinkok to simplify the execution
-        $quickFinkok = new QuickFinkok($this->createSettingsFromEnvironment());
-        $downloadResult = $quickFinkok->retentionDownload($currentResult->uuid(), 'EKU9003173C9');
-
-        $this->assertXmlStringEqualsXmlString(
-            $currentResult->xml(),
-            $downloadResult->xml(),
-            'Created and downloaded RET must be XML equal'
-        );
-        $this->assertSame(
-            $currentResult->xml(),
-            $downloadResult->xml(),
-            'Created and downloaded RET must be identical'
-        );
+        $result = $this->stampRetentionPreCfdi('invalid xml');
+        $this->assertEmpty($result->xml());
+        $this->assertEmpty($result->uuid());
+        $this->assertTrue($result->hasAlerts());
     }
 }

--- a/tests/Integration/Services/Retentions/StampServiceTest.php
+++ b/tests/Integration/Services/Retentions/StampServiceTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Integration\Services\Retentions;
+
+use PhpCfdi\Finkok\Services\Retentions\StampService;
+
+final class StampServiceTest extends RetentionsTestCase
+{
+    protected function createService(): StampService
+    {
+        return new StampService($this->createSettingsFromEnvironment());
+    }
+
+    public function testStampInvalidXml(): void
+    {
+        $result = $this->stampRetentionPreCfdi('invalid xml');
+        $this->assertEmpty($result->xml());
+        $this->assertEmpty($result->uuid());
+        $this->assertTrue($result->hasAlerts());
+    }
+
+    public function testStampValidPreCfdiRetentions(): void
+    {
+        $result = $this->currentRetentionsStampResult();
+        $this->assertSame('Comprobante timbrado satisfactoriamente', $result->statusCode());
+        $this->assertNotEmpty($result->xml());
+        $this->assertNotEmpty($result->uuid());
+        $this->assertNotEmpty($result->seal());
+    }
+
+    public function testStampValidPreCfdiRetentionsTwice(): void
+    {
+        $currentResult = $this->currentRetentionsStampResult();
+        $this->assertNotEmpty($currentResult->uuid(), 'There must be an already stamped precfdi');
+
+        $preCfdi = $this->currentRetentionsPreCfdi(); // this is the same precfdi used on currentStampResult
+        $repeatedResult = $this->stampRetentionPreCfdi($preCfdi);
+
+        $this->assertSame($currentResult->uuid(), $repeatedResult->uuid(), 'UUID on first and second stamp must match');
+        $this->assertSame('Comprobante timbrado previamente', $repeatedResult->statusCode());
+        $this->assertSame('El CFDI contiene un timbre previo', $repeatedResult->alerts()->first()->message());
+    }
+}

--- a/tests/Integration/Services/Retentions/StampServiceTest.php
+++ b/tests/Integration/Services/Retentions/StampServiceTest.php
@@ -4,15 +4,8 @@ declare(strict_types=1);
 
 namespace PhpCfdi\Finkok\Tests\Integration\Services\Retentions;
 
-use PhpCfdi\Finkok\Services\Retentions\StampService;
-
 final class StampServiceTest extends RetentionsTestCase
 {
-    protected function createService(): StampService
-    {
-        return new StampService($this->createSettingsFromEnvironment());
-    }
-
     public function testStampInvalidXml(): void
     {
         $result = $this->stampRetentionPreCfdi('invalid xml');

--- a/tests/Integration/Services/Retentions/StampServiceTest.php
+++ b/tests/Integration/Services/Retentions/StampServiceTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PhpCfdi\Finkok\Tests\Integration\Services\Retentions;
 
+use PhpCfdi\Finkok\QuickFinkok;
+
 final class StampServiceTest extends RetentionsTestCase
 {
     public function testStampInvalidXml(): void
@@ -34,5 +36,26 @@ final class StampServiceTest extends RetentionsTestCase
         $this->assertSame($currentResult->uuid(), $repeatedResult->uuid(), 'UUID on first and second stamp must match');
         $this->assertSame('Comprobante timbrado previamente', $repeatedResult->statusCode());
         $this->assertSame('El CFDI contiene un timbre previo', $repeatedResult->alerts()->first()->message());
+    }
+
+    public function testDownloadRetentionRecentlyCreated(): void
+    {
+        $currentResult = $this->currentRetentionsStampResult();
+        $this->assertNotEmpty($currentResult->uuid(), 'There must be an already stamped precfdi');
+
+        // consume quickfinkok to simplify the execution
+        $quickFinkok = new QuickFinkok($this->createSettingsFromEnvironment());
+        $downloadResult = $quickFinkok->retentionDownload($currentResult->uuid(), 'EKU9003173C9');
+
+        $this->assertXmlStringEqualsXmlString(
+            $currentResult->xml(),
+            $downloadResult->xml(),
+            'Created and downloaded RET must be XML equal'
+        );
+        $this->assertSame(
+            $currentResult->xml(),
+            $downloadResult->xml(),
+            'Created and downloaded RET must be identical'
+        );
     }
 }

--- a/tests/Integration/Services/Retentions/StampServiceTest.php
+++ b/tests/Integration/Services/Retentions/StampServiceTest.php
@@ -4,11 +4,17 @@ declare(strict_types=1);
 
 namespace PhpCfdi\Finkok\Tests\Integration\Services\Retentions;
 
+use PhpCfdi\Finkok\Services\Retentions\StampCommand;
+
 final class StampServiceTest extends RetentionsTestCase
 {
     public function testStampValidPreCfdiRetentions(): void
     {
-        $result = $this->currentRetentionsStampResult();
+        $preCfdi = $this->newRetentionsPreCfdi();
+        $command = new StampCommand($preCfdi);
+        $service = $this->createStampService();
+        $result = $service->stamp($command);
+
         $this->assertSame('Comprobante timbrado satisfactoriamente', $result->statusCode());
         $this->assertNotEmpty($result->xml());
         $this->assertNotEmpty($result->uuid());

--- a/tests/Integration/Services/Utilities/DownloadXmlServiceTest.php
+++ b/tests/Integration/Services/Utilities/DownloadXmlServiceTest.php
@@ -40,11 +40,12 @@ class DownloadXmlServiceTest extends IntegrationTestCase
             'Finkok does not return equal XML for recently created stamp using get_xml'
         );
         $this->assertEmpty($result->error(), 'Finkok must not return an error');
-        // finkok ticket: https://support.finkok.com/support/tickets/41438
-        // $this->assertSame(
-        //     $previousStamp->xml(),
-        //     $result->xml(),
-        //     'Finkok does not return exactly the same XML for recently created stamp using get_xml'
-        // );
+        // see finkok ticket: https://support.finkok.com/support/tickets/41438
+        // it was not returning the xml header
+        $this->assertSame(
+            $previousStamp->xml(),
+            $result->xml(),
+            'Finkok does not return exactly the same XML for recently created stamp using get_xml'
+        );
     }
 }

--- a/tests/Unit/Helpers/GetSatStatusExtractorTest.php
+++ b/tests/Unit/Helpers/GetSatStatusExtractorTest.php
@@ -40,4 +40,12 @@ EOT;
         $this->assertSame('12345678-1234-1234-1234-000000000001', $command->uuid());
         $this->assertSame('123.45', $command->total());
     }
+
+    public function testConstructWithOtherXml(): void
+    {
+        $fakeCfdi = '<xml/>';
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to obtain the expression values');
+        GetSatStatusExtractor::fromXmlString($fakeCfdi);
+    }
 }

--- a/tests/Unit/QuickFinkokTest.php
+++ b/tests/Unit/QuickFinkokTest.php
@@ -427,4 +427,13 @@ EOT;
         $this->performTestOnLatestCall('stamp', ['xml' => 'precfdi']);
         $this->assertEquals($rawData, $result->rawData());
     }
+
+    public function testRetentionDownload(): void
+    {
+        $rawData = (object) ['get_xmlResult' => (object) []];
+        $finkok = $this->createdPreparedQuickFinkok($rawData);
+        $result = $finkok->retentionDownload('x-uuid', 'x-rfc');
+        $this->performTestOnLatestCall('get_xml', ['invoice_type' => 'R']);
+        $this->assertEquals($rawData, $result->rawData());
+    }
 }

--- a/tests/Unit/QuickFinkokTest.php
+++ b/tests/Unit/QuickFinkokTest.php
@@ -436,4 +436,13 @@ EOT;
         $this->performTestOnLatestCall('get_xml', ['invoice_type' => 'R']);
         $this->assertEquals($rawData, $result->rawData());
     }
+
+    public function testRetentionStamped(): void
+    {
+        $rawData = json_decode($this->fileContentPath('retentions-stamped-response.json'));
+        $finkok = $this->createdPreparedQuickFinkok($rawData);
+        $result = $finkok->retentionStamped('x-xml');
+        $this->performTestOnLatestCall('stamped', ['xml' => 'x-xml']);
+        $this->assertEquals($rawData, $result->rawData());
+    }
 }

--- a/tests/Unit/QuickFinkokTest.php
+++ b/tests/Unit/QuickFinkokTest.php
@@ -418,4 +418,13 @@ EOT;
         $this->assertFalse($result->success());
         $this->assertSame('Unable to get contracts: FOO', $result->message());
     }
+
+    public function testRetentionStamp(): void
+    {
+        $rawData = json_decode($this->fileContentPath('retentions-stamp-response.json'));
+        $finkok = $this->createdPreparedQuickFinkok($rawData);
+        $result = $finkok->retentionStamp('precfdi');
+        $this->performTestOnLatestCall('stamp', ['xml' => 'precfdi']);
+        $this->assertEquals($rawData, $result->rawData());
+    }
 }

--- a/tests/Unit/Services/Retentions/CancelSignatureCommandTest.php
+++ b/tests/Unit/Services/Retentions/CancelSignatureCommandTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Unit\Services\Retentions;
+
+use PhpCfdi\Finkok\Definitions\CancelStorePending;
+use PhpCfdi\Finkok\Services\Retentions\CancelSignatureCommand;
+use PhpCfdi\Finkok\Tests\TestCase;
+
+class CancelSignatureCommandTest extends TestCase
+{
+    public function testCommandDefaultValue(): void
+    {
+        $command = new CancelSignatureCommand('xml');
+        $this->assertFalse($command->storePending()->asBool(), 'Default value for store pending should be FALSE');
+    }
+
+    public function testCommandValues(): void
+    {
+        $storePending = CancelStorePending::yes();
+        $command = new CancelSignatureCommand('xml', $storePending);
+        $this->assertSame('xml', $command->xml());
+        $this->assertEquals($storePending, $command->storePending());
+    }
+}

--- a/tests/Unit/Services/Retentions/CancelSignatureResultTest.php
+++ b/tests/Unit/Services/Retentions/CancelSignatureResultTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Unit\Services\Retentions;
+
+use PhpCfdi\Finkok\Services\Retentions\CancelSignatureResult;
+use PhpCfdi\Finkok\Tests\TestCase;
+
+class CancelSignatureResultTest extends TestCase
+{
+    public function testResultUsingPredefinedResponses(): void
+    {
+        $data = json_decode($this->fileContentPath('retentions-cancelsignature-response.json'));
+        $result = new CancelSignatureResult($data);
+        $this->assertCount(2, $result->documents());
+        $this->assertSame('11111111-2222-3333-4444-000000000001', $result->documents()->get(0)->uuid());
+        $this->assertSame('voucher', $result->voucher());
+        $this->assertSame('2019-04-05 16:29:47.138032', $result->date());
+        $this->assertSame('LAN7008173R5', $result->rfc());
+        $this->assertSame('304', $result->statusCode());
+    }
+}

--- a/tests/Unit/Services/Retentions/CancelSignatureServiceTest.php
+++ b/tests/Unit/Services/Retentions/CancelSignatureServiceTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Unit\Services\Retentions;
+
+use PhpCfdi\Finkok\Definitions\CancelStorePending;
+use PhpCfdi\Finkok\Definitions\Services;
+use PhpCfdi\Finkok\Services\Retentions\CancelSignatureCommand;
+use PhpCfdi\Finkok\Services\Retentions\CancelSignatureService;
+use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
+use PhpCfdi\Finkok\Tests\TestCase;
+
+class CancelSignatureServiceTest extends TestCase
+{
+    public function testServiceUsingPreparedResult(): void
+    {
+        $preparedResult = json_decode(TestCase::fileContentPath('retentions-cancelsignature-response.json'));
+
+        $soapFactory = new FakeSoapFactory();
+        $soapFactory->preparedResult = $preparedResult;
+
+        $settings = $this->createSettingsFromEnvironment($soapFactory);
+        $service = new CancelSignatureService($settings);
+
+        $command = new CancelSignatureCommand('x-xml', CancelStorePending::yes());
+        $result = $service->cancelSignature($command);
+        $this->assertCount(2, $result->documents());
+        $this->assertSame('voucher', $result->voucher());
+        $this->assertSame('LAN7008173R5', $result->rfc());
+        $this->assertSame('2019-04-05 16:29:47.138032', $result->date());
+        $this->assertSame('304', $result->statusCode());
+        $this->assertSame('x-seguimiento-cancelacion', $result->tracing());
+
+        $caller = $soapFactory->latestSoapCaller;
+        $this->assertStringEndsWith(Services::retentions()->value(), $soapFactory->latestWsdlLocation);
+        $this->assertSame('cancel_signature', $caller->latestCallMethodName);
+        $this->assertArrayHasKey('xml', $caller->latestCallParameters);
+        $this->assertSame($command->xml(), $caller->latestCallParameters['xml']);
+        $this->assertArrayHasKey('store_pending', $caller->latestCallParameters);
+        $this->assertSame($command->storePending()->asBool(), $caller->latestCallParameters['store_pending']);
+    }
+}

--- a/tests/Unit/Services/Retentions/StampCommandTest.php
+++ b/tests/Unit/Services/Retentions/StampCommandTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Unit\Services\Retentions;
+
+use PhpCfdi\Finkok\Services\Retentions\StampCommand;
+use PhpCfdi\Finkok\Tests\Factories\RandomPreCfdiRetention;
+use PhpCfdi\Finkok\Tests\TestCase;
+
+class StampCommandTest extends TestCase
+{
+    public function testSignStampCommandCanReceiveAPrecfdi(): void
+    {
+        $xml = (new RandomPreCfdiRetention())->createValid();
+        $command = new StampCommand($xml);
+        $this->assertSame($xml, $command->xml());
+    }
+}

--- a/tests/Unit/Services/Retentions/StampResultTest.php
+++ b/tests/Unit/Services/Retentions/StampResultTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Unit\Services\Retentions;
+
+use PhpCfdi\Finkok\Services\Retentions\StampResult;
+use PhpCfdi\Finkok\Tests\TestCase;
+
+class StampResultTest extends TestCase
+{
+    public function testUsingKnownStampResponse(): void
+    {
+        $data = json_decode($this->fileContentPath('retentions-stamp-response.json'));
+        $response = new StampResult($data);
+        $this->assertSame('x-xml', $response->xml());
+        $this->assertSame('x-uuid', $response->uuid());
+        $this->assertSame('x-date', $response->date());
+        $this->assertSame('x-fault-string', $response->faultString());
+        $this->assertSame('x-fault-code', $response->faultCode());
+        $this->assertSame('x-code-status', $response->statusCode());
+        $this->assertSame('x-sat-seal', $response->seal());
+        $this->assertSame('x-no-certificado-sat', $response->certificateSat());
+        $this->assertCount(2, $response->alerts());
+        foreach ($response->alerts() as $index => $alert) {
+            $key = sprintf('x%d', $index + 1);
+            $this->assertSame("$key-00001", $alert->id());
+            $this->assertSame("$key-rfc", $alert->rfc());
+            $this->assertSame("$key-uuid", $alert->uuid());
+            $this->assertSame("$key-error-code", $alert->errorCode());
+            $this->assertSame("$key-work-process-id", $alert->workProcessId());
+            $this->assertSame("$key-message", $alert->message());
+            $this->assertSame("$key-extra-info", $alert->extraInfo());
+            $this->assertSame("$key-no-certificado-pac", $alert->certificatePac());
+            $this->assertSame("$key-registry-date", $alert->date());
+        }
+    }
+}

--- a/tests/Unit/Services/Retentions/StampServiceTest.php
+++ b/tests/Unit/Services/Retentions/StampServiceTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Unit\Services\Retentions;
+
+use PhpCfdi\Finkok\Services\Retentions\StampCommand;
+use PhpCfdi\Finkok\Services\Retentions\StampService;
+use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
+use PhpCfdi\Finkok\Tests\TestCase;
+
+class StampServiceTest extends TestCase
+{
+    public function testSignStampSendXmlAndProcessPreparedResult(): void
+    {
+        $preparedResult = json_decode(TestCase::fileContentPath('retentions-stamp-response.json'));
+
+        $soapFactory = new FakeSoapFactory();
+        $soapFactory->preparedResult = $preparedResult;
+
+        $settings = $this->createSettingsFromEnvironment($soapFactory);
+        $service = new StampService($settings);
+        $command = new StampCommand('x-precfdi');
+
+        $service->stamp($command);
+
+        $caller = $soapFactory->latestSoapCaller;
+        $this->assertSame('stamp', $caller->latestCallMethodName);
+        $this->assertArrayHasKey('xml', $caller->latestCallParameters);
+        $this->assertSame('x-precfdi', $caller->latestCallParameters['xml']);
+    }
+}

--- a/tests/Unit/Services/Retentions/StampedCommandTest.php
+++ b/tests/Unit/Services/Retentions/StampedCommandTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Unit\Services\Retentions;
+
+use PhpCfdi\Finkok\Services\Retentions\StampedCommand;
+use PhpCfdi\Finkok\Tests\Factories\RandomPreCfdiRetention;
+use PhpCfdi\Finkok\Tests\TestCase;
+
+class StampedCommandTest extends TestCase
+{
+    public function testSignStampedCommandCanReceiveAPrecfdi(): void
+    {
+        $xml = (new RandomPreCfdiRetention())->createValid();
+        $command = new StampedCommand($xml);
+        $this->assertSame($xml, $command->xml());
+    }
+}

--- a/tests/Unit/Services/Retentions/StampedResultTest.php
+++ b/tests/Unit/Services/Retentions/StampedResultTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Unit\Services\Retentions;
+
+use PhpCfdi\Finkok\Services\Retentions\StampedResult;
+use PhpCfdi\Finkok\Tests\TestCase;
+
+class StampedResultTest extends TestCase
+{
+    public function testUsingKnownStampResponse(): void
+    {
+        $data = json_decode($this->fileContentPath('retentions-stamped-response.json'));
+        $response = new StampedResult($data);
+        $this->assertSame('x-xml', $response->xml());
+        $this->assertSame('x-uuid', $response->uuid());
+        $this->assertSame('x-date', $response->date());
+        $this->assertSame('x-fault-string', $response->faultString());
+        $this->assertSame('x-fault-code', $response->faultCode());
+        $this->assertSame('x-code-status', $response->statusCode());
+        $this->assertSame('x-sat-seal', $response->seal());
+        $this->assertSame('x-no-certificado-sat', $response->certificateSat());
+        $this->assertCount(2, $response->alerts());
+        foreach ($response->alerts() as $index => $alert) {
+            $key = sprintf('x%d', $index + 1);
+            $this->assertSame("$key-00001", $alert->id());
+            $this->assertSame("$key-rfc", $alert->rfc());
+            $this->assertSame("$key-uuid", $alert->uuid());
+            $this->assertSame("$key-error-code", $alert->errorCode());
+            $this->assertSame("$key-work-process-id", $alert->workProcessId());
+            $this->assertSame("$key-message", $alert->message());
+            $this->assertSame("$key-extra-info", $alert->extraInfo());
+            $this->assertSame("$key-no-certificado-pac", $alert->certificatePac());
+            $this->assertSame("$key-registry-date", $alert->date());
+        }
+    }
+}

--- a/tests/Unit/Services/Retentions/StampedServiceTest.php
+++ b/tests/Unit/Services/Retentions/StampedServiceTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Unit\Services\Retentions;
+
+use PhpCfdi\Finkok\Services\Retentions\StampedCommand;
+use PhpCfdi\Finkok\Services\Retentions\StampedService;
+use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
+use PhpCfdi\Finkok\Tests\TestCase;
+
+class StampedServiceTest extends TestCase
+{
+    public function testSignStampSendXmlAndProcessPreparedResult(): void
+    {
+        $preparedResult = json_decode(TestCase::fileContentPath('retentions-stamped-response.json'));
+
+        $soapFactory = new FakeSoapFactory();
+        $soapFactory->preparedResult = $preparedResult;
+
+        $settings = $this->createSettingsFromEnvironment($soapFactory);
+        $service = new StampedService($settings);
+        $command = new StampedCommand('x-precfdi');
+
+        $service->stamped($command);
+
+        $caller = $soapFactory->latestSoapCaller;
+        $this->assertSame('stamped', $caller->latestCallMethodName);
+        $this->assertArrayHasKey('xml', $caller->latestCallParameters);
+        $this->assertSame('x-precfdi', $caller->latestCallParameters['xml']);
+    }
+}

--- a/tests/Unit/Services/Stamping/QueryPendingCommandTest.php
+++ b/tests/Unit/Services/Stamping/QueryPendingCommandTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Unit\Services\Stamping;
+
+use PhpCfdi\Finkok\Services\Stamping\QueryPendingCommand;
+use PhpCfdi\Finkok\Tests\TestCase;
+
+class QueryPendingCommandTest extends TestCase
+{
+    public function testCreateCommand(): void
+    {
+        $uuid = '11111111-2222-3333-4444-000000000001';
+        $command = new QueryPendingCommand($uuid);
+        $this->assertSame($uuid, $command->uuid());
+    }
+}

--- a/tests/Unit/Services/Stamping/QueryPendingResultTest.php
+++ b/tests/Unit/Services/Stamping/QueryPendingResultTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Unit\Services\Stamping;
+
+use PhpCfdi\Finkok\Services\Stamping\QueryPendingResult;
+use PhpCfdi\Finkok\Tests\TestCase;
+
+class QueryPendingResultTest extends TestCase
+{
+    public function testUsingKnownStampResponse(): void
+    {
+        $data = json_decode($this->fileContentPath('querypending-response.json'));
+        $response = new QueryPendingResult($data);
+        $this->assertSame('S', $response->status());
+        $this->assertSame('<xml/>', $response->xml());
+        $this->assertSame('uuid', $response->uuid());
+        $this->assertSame('uuid_status', $response->uuidStatus());
+        $this->assertSame('next_attempt', $response->nextAttempt());
+        $this->assertSame('1', $response->attempts());
+        $this->assertSame('error', $response->error());
+        $this->assertSame('date', $response->date());
+    }
+}

--- a/tests/_files/retentions-cancelsignature-response.json
+++ b/tests/_files/retentions-cancelsignature-response.json
@@ -1,0 +1,23 @@
+{
+  "cancel_signatureResult": {
+    "Folios": {
+      "Folio": [
+        {
+          "UUID": "11111111-2222-3333-4444-000000000001",
+          "EstatusUUID": "201",
+          "EstatusCancelacion": "Cancelado sin aceptación"
+        },
+        {
+          "UUID": "11111111-2222-3333-4444-000000000002",
+          "EstatusUUID": "no_cancelable",
+          "EstatusCancelacion": ""
+        }
+      ]
+    },
+    "Acuse": "voucher",
+    "Fecha": "2019-04-05 16:29:47.138032",
+    "RfcEmisor": "LAN7008173R5",
+    "CodEstatus": "304",
+    "SeguimientoCancelacion": "x-seguimiento-cancelacion"
+  }
+}

--- a/tests/_files/retentions-stamp-response.json
+++ b/tests/_files/retentions-stamp-response.json
@@ -1,0 +1,38 @@
+{
+    "stampResult": {
+        "xml": "x-xml",
+        "UUID": "x-uuid",
+        "Fecha": "x-date",
+        "faultstring": "x-fault-string",
+        "faultcode": "x-fault-code",
+        "CodEstatus": "x-code-status",
+        "SatSeal": "x-sat-seal",
+        "NoCertificadoSAT": "x-no-certificado-sat",
+        "Incidencias": {
+            "Incidencia": [
+                {
+                    "IdIncidencia": "x1-00001",
+                    "RfcEmisor": "x1-rfc",
+                    "Uuid": "x1-uuid",
+                    "CodigoError": "x1-error-code",
+                    "WorkProcessId": "x1-work-process-id",
+                    "MensajeIncidencia": "x1-message",
+                    "ExtraInfo": "x1-extra-info",
+                    "NoCertificadoPac": "x1-no-certificado-pac",
+                    "FechaRegistro": "x1-registry-date"
+                },
+                {
+                    "IdIncidencia": "x2-00001",
+                    "RfcEmisor": "x2-rfc",
+                    "Uuid": "x2-uuid",
+                    "CodigoError": "x2-error-code",
+                    "WorkProcessId": "x2-work-process-id",
+                    "MensajeIncidencia": "x2-message",
+                    "ExtraInfo": "x2-extra-info",
+                    "NoCertificadoPac": "x2-no-certificado-pac",
+                    "FechaRegistro": "x2-registry-date"
+                }
+            ]
+        }
+    }
+}

--- a/tests/_files/retentions-stamped-response.json
+++ b/tests/_files/retentions-stamped-response.json
@@ -1,0 +1,38 @@
+{
+    "stampedResult": {
+        "xml": "x-xml",
+        "UUID": "x-uuid",
+        "Fecha": "x-date",
+        "faultstring": "x-fault-string",
+        "faultcode": "x-fault-code",
+        "CodEstatus": "x-code-status",
+        "SatSeal": "x-sat-seal",
+        "NoCertificadoSAT": "x-no-certificado-sat",
+        "Incidencias": {
+            "Incidencia": [
+                {
+                    "IdIncidencia": "x1-00001",
+                    "RfcEmisor": "x1-rfc",
+                    "Uuid": "x1-uuid",
+                    "CodigoError": "x1-error-code",
+                    "WorkProcessId": "x1-work-process-id",
+                    "MensajeIncidencia": "x1-message",
+                    "ExtraInfo": "x1-extra-info",
+                    "NoCertificadoPac": "x1-no-certificado-pac",
+                    "FechaRegistro": "x1-registry-date"
+                },
+                {
+                    "IdIncidencia": "x2-00001",
+                    "RfcEmisor": "x2-rfc",
+                    "Uuid": "x2-uuid",
+                    "CodigoError": "x2-error-code",
+                    "WorkProcessId": "x2-work-process-id",
+                    "MensajeIncidencia": "x2-message",
+                    "ExtraInfo": "x2-extra-info",
+                    "NoCertificadoPac": "x2-no-certificado-pac",
+                    "FechaRegistro": "x2-registry-date"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
- Documentar la solución del problema de acuse recibido al cancelar y al solicitar. Finkok ticket: `#41435`. 
- Se agrega el método `StampingAlert::extraInfo()` para obtener la respuesta de la incidencia en `ExtraInfo`.
- Se agrega el método `StampingResult::faultCode()` para obtener la respuesta en `faultcode`.
- Se renombra el método `StampingResult::faultstring()` a `StampingResult::faultString()`.
- Se agrega el servicio de retenciones (para CFDI de retenciones e información de pagos).
- Se crean fábricas básicas de CFDI RET para poder testear.
- Se agregan métodos de retenciones (comando, resultado, servicio y método en `QuickFinkok`):
    - Timbrado de retención: La respuesta tiene campos idénticos al timbrado de CFDI.
    - Cancelación de retención: La respuesta tiene campos idénticos y adicionales al timbrado de CFDI.
    - Para poder cancelar un RET, fue necesario actualizar a `phpcfdi/xml-cancelacion: ^1.1.0`.
- El objeto `GetSatStatusExtractor` podía procesar CFDI 3.2, CFDI 3.3 y RET 1.0, sin embargo el método `get_sat_status`
  sólo puede trabajar con CFDI 3.2, CFDI 3.3, se hacen las adecuaciones correspondientes.
- Desarrollo:
    - Se crearon pruebas unitarias para `QueryPendingCommand` y `QueryPendingResult`.
    - Se reconstruye `createGetSatStatusCommandFromCfdiContents` para que use el helper `GetSatStatusExtractor`.
    - Se mejoran las acciones `resetCustomerAccountToOnDemand` y `resetCustomerAccountToPrepaidWithZeroCredits`.
    - Se actualiza de `phpstan/phpstan-shim: ^0.11` a `phpstan/phpstan: ^0.12`.
    - Se actualiza a `phpunit/phpunit: ^8.5` porque el XSD de la versión previa no está disponible.
    - Se crean nuevas tareas de desarrollo y mejora. 
- Issues: A pesar de haber impementado la Cancelación de retención, el test de integración está fallando por un
  error en el servicio de pruebas del SAT.