### PR TITLE
Fix test for get_related_signature

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,13 @@ Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor e
   no debe usar la opción de nulo, fue puesta para compatibilidad con versiones previas a `0.2.2`.
   No así el las fachadas `Finkok` y `QuickFinkok`.
 
+## Version 0.2.7 2020-02-10
+
+- En las pruebas de integración del servicio `get_related_signature` el SAT tarda en vincular los CFDI recientemente
+  creados, lo que ocasiona que la prueba falle invariablemente al detectar el error
+  `2001 - No Existen cfdi relacionados al folio fiscal.`.
+  Se ha modificado la prueba para que, si encuentra dicho error no rompa el ciclo de testeo y lo vuelva a intentar.
+
 ## Version 0.2.6 2020-01-24
 
 - Documentar la solución del problema de acuse recibido al cancelar y al solicitar. Finkok ticket: `#41435`. 

--- a/tests/Integration/Services/Cancel/GetRelatedSignatureServiceTest.php
+++ b/tests/Integration/Services/Cancel/GetRelatedSignatureServiceTest.php
@@ -63,8 +63,10 @@ class GetRelatedSignatureServiceTest extends IntegrationTestCase
         $maxtime = strtotime('+5 minutes');
         do {
             $result = $service->getRelatedSignature($command);
-            // SAT is not resolving correctly because I ask for related immediately
-            if ('' !== $result->error()) {
+            // Break the loop if SAT return an error, but the error is not:
+            // 2001 - No Existen cfdi relacionados al folio fiscal.
+            // Testing only: in the wild it is expected to ask for related several seconds after the CFDI were created
+            if ('' !== $result->error() && '2001' !== substr($result->error(), 0, 4)) {
                 break;
             }
             if (1 === $result->parents()->count() && 1 === $result->children()->count()) {


### PR DESCRIPTION
It should wait to SAT to relate the recently created CFDI (skip error 2001 - No Existen cfdi relacionados al folio fiscal.)