### PR TITLE
Nueva versión con soporte PHP 8.0

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -7,7 +7,6 @@ filter:
 build:
   dependencies:
     override:
-      - composer self-update --no-interaction --no-progress
       - composer remove squizlabs/php_codesniffer friendsofphp/php-cs-fixer phpstan/phpstan --dev --no-interaction --no-progress --no-update
       - composer install --no-interaction
   nodes:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
 
 script:
   - vendor/bin/php-cs-fixer fix --verbose
-  - vendor/bin/phpcbf --colors -sp src/ tests/
+  - vendor/bin/phpcs --colors -sp src/ tests/
   - vendor/bin/phpunit --testdox --verbose tests/Unit/
   - vendor/bin/phpstan analyse --no-progress --verbose --level max src/ tests/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 # php compatibility
-php: ["7.2", "7.3", "7.4"]
+php: ["7.3", "7.4"]
 
 cache:
   - directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 # php compatibility
-php: ["7.3", "7.4"]
+php: ["7.3", "7.4", "8.0"]
 
 cache:
   - directories:

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Durante el proceso de implementación he creado diversas notas y documentos:
     - [X] Falta servicio que no requiera CSD/FIEL para aceptar o rechazar una solicitud de cancelación
     - [X] Falta servicio que no requiera CSD/FIEL para obtener los CFDI relacionados
     - [X] [El acuse de cancelación entregado al cancelar y al solicitar el acuse no coinciden](docs/issues/AcuseCancelacionNoCoincidente.md)
-    - [ ] [Error de cancelación de retenciones 1308 - Certificado revocado o caduco](docs/issues/CancelacionRetencionesError1308.md)
+    - [X] [Error de cancelación de retenciones 1308 - Certificado revocado o caduco](docs/issues/CancelacionRetencionesError1308.md)
 
 ## Compatilibilidad
 

--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ Finkok tiene dos métodos de firmado: `stamp` y `quickstamp`.
 * `stamp(Stamping\StampingCommand $command): Stamping\StampingResult`
 * `quickstamp(Stamping\StampingCommand $command): Stamping\StampingResult`
 
-`stamped` para revisar si previamente se generó un cfdi
+El servicio `stamped` para revisar si previamente se generó un cfdi:
 
 * `stamped(Stamping\StampingCommand $command): Stamping\StampingResult`
 
-y `stampQueryPending` por si estás usando el `pending buffer` (que te recomiendo no hacerlo).
+El servicio `stampQueryPending` por si estás usando `pending buffer` (que te recomiendo no hacerlo):
 
 * `stampQueryPending(Stamping\QueryPendingCommand $command): Stamping\QueryPendingResult`
 
@@ -244,7 +244,7 @@ sin temor a romper tu aplicación.
 ## Contribuciones
 
 Las contribuciones con bienvenidas. Por favor lee [CONTRIBUTING][] para más detalles
-y recuerda revisar el archivo de tareas pendientes [TODO][] y el [CHANGELOG][].
+y recuerda revisar el archivo de tareas pendientes [TODO][] y el archivo [CHANGELOG][].
 
 ## Copyright and License
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,11 @@ Esta librería se mantendrá compatible con al menos la versión con
 También utilizamos [Versionado Semántico 2.0.0](docs/SEMVER.md) por lo que puedes usar esta librería
 sin temor a romper tu aplicación.
 
+| Versión de la librería | Versión de PHP | Fecha de lanzamiento |
+| ---                    | ---            | ---                  |
+| 0.1.0                  | 7.2, 7.3 y 7.4 | 2019-03-29           |
+| 0.3.0                  | 7.3, 7.4 y 8.0 | 2021-03-18           |
+
 ## Contribuciones
 
 Las contribuciones con bienvenidas. Por favor lee [CONTRIBUTING][] para más detalles

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.3",
         "ext-json": "*",
         "ext-soap": "*",
         "ext-dom": "*",
@@ -40,7 +40,7 @@
         "ext-fileinfo": "*",
         "symfony/dotenv": "^5.1",
         "eclipxe/cfdiutils": "^2.10",
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.4",
         "phpstan/phpstan": "^0.12.54"

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "require-dev": {
         "ext-fileinfo": "*",
         "symfony/dotenv": "^5.1",
-        "eclipxe/cfdiutils": "^2.10",
+        "eclipxe/cfdiutils": "^2.15",
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.4",

--- a/composer.json
+++ b/composer.json
@@ -56,29 +56,28 @@
         }
     },
     "scripts": {
-        "dev:build": ["@dev:fix-style", "@dev:test"],
+        "dev:build": ["@dev:fix-style", "@dev:check-style", "@dev:test"],
         "dev:check-style": [
-            "vendor/bin/php-cs-fixer fix --dry-run --verbose",
-            "vendor/bin/phpcs --colors -sp src/ tests/"
+            "@php vendor/bin/php-cs-fixer fix --dry-run --verbose",
+            "@php vendor/bin/phpcs --colors -sp src/ tests/"
         ],
         "dev:fix-style": [
-            "vendor/bin/php-cs-fixer fix --verbose",
-            "vendor/bin/phpcbf --colors -sp src/ tests/"
+            "@php vendor/bin/php-cs-fixer fix --verbose",
+            "@php vendor/bin/phpcbf --colors -sp src/ tests/"
         ],
         "dev:test": [
-            "@dev:check-style",
-            "vendor/bin/phpunit --testdox --verbose --stop-on-failure tests/Unit",
-            "vendor/bin/phpstan analyse --no-progress --verbose --level max src/ tests/"
+            "@php vendor/bin/phpunit --testdox --verbose --stop-on-failure tests/Unit",
+            "@php vendor/bin/phpstan analyse --no-progress --verbose --level max src/ tests/"
         ],
         "dev:coverage": [
             "@php -dzend_extension=xdebug.so vendor/bin/phpunit --verbose --coverage-html build/coverage/html/"
         ]
     },
     "scripts-descriptions": {
-        "dev:build": "DEV: run dev:fix-style dev:tests and dev:docs, run before pull request",
+        "dev:build": "DEV: run dev:fix-style dev:check-style and dev:tests, run before pull request",
         "dev:check-style": "DEV: search for code style errors using php-cs-fixer and phpcs",
         "dev:fix-style": "DEV: fix code style errors using php-cs-fixer and phpcbf",
-        "dev:test": "DEV: run dev:check-style, phpunit and phpstan",
+        "dev:test": "DEV: run phpunit and phpstan",
         "dev:coverage": "DEV: run phpunit with xdebug and storage coverage in build/coverage/html/"
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,15 +2,30 @@
 
 Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor el control de versiones.
 
-## Cambios para la siguiente versión que rompa compatibilidad
+## Versión 0.3.0 2021-03-21
 
+- Se elimina el soporte y dependencia de PHP 7.2.
+- Se agrega el soporte de PHP 7.3.
+- Se actualiza PHPUnit de 8.5 a 9.5.
 - `PhpCfdi\Finkok\Services\Utilities\DatetimeService::datetime(DatetimeCommand $command = null)`
-  no debe usar la opción de nulo, fue puesta para compatibilidad con versiones previas a `0.2.2`.
-  No así el las fachadas `Finkok` y `QuickFinkok`.
+  no debe usar la opción de nulo, fue puesta para compatibilidad con versiones previas a `0.2.2`,
+  no es así en las fachadas `Finkok` y `QuickFinkok`.
+- Limpieza de código:
+  - Remover variables locales innecesarias.
+  - Remover código innecesario (inicializaciones a null, variables privadas sin uso).
+  - Múltiples anotaciones para evitar alertas de PHPStorm.
 
-## Version UNRELEASED 2020-10-14
+Cambios en entorno de desarrollo:
 
-Cambios en el entorno de pruebas. Solo se afecta la rama principal, no se libera una nueva versión.
+- Se corrigen las pruebas de integración porque el sistema de pruebas del SAT reporta errores de sincronización.
+- En desarrollo se depende ahora de `eclipxe/cfdiutils` compatible con PHP 8.0.
+- Se corrigieron los scripts de `composer.json`.
+- Los casos de pruebas son clases finales.
+- Corrección de Travis-CI, estaba usando `phpcbf` en lugar de `phpcs`.
+- Se agrega PHP 8.0 a la matriz de pruebas de Travis-CI.
+- Se elimina la actualización de composer en Scrutinizer, el sistema es de solo lectura.
+
+Cambios en el entorno de pruebas (2020-10-14). Solo se afecta la rama principal, no se libera una nueva versión.
 
 - El build estaba roto por un problema de tipos detectado por PHPStan debido a que a partir de la versión `0.12.54`
   ya detecta las estructuras de control de flujo de PHPUnit.
@@ -18,9 +33,7 @@ Cambios en el entorno de pruebas. Solo se afecta la rama principal, no se libera
   certificados intermedios, lo solucionaron de inmediato: <https://support.finkok.com/support/tickets/46648>.
 - Cambios menores en las pruebas.
 
-## Version UNRELEASED 2020-09-18
-
-Cambios en el entorno de pruebas. Solo se afecta la rama principal, no se libera una nueva versión.
+Cambios en el entorno de pruebas (2020-09-18). Solo se afecta la rama principal, no se libera una nueva versión.
 
 - El build estaba roto por un problema de tipos detectado por `phpstan` debido a un "soft breaking compatibility change"
   introducido por `symfony/dotenv:5.1`, se corrige el problema en `tests/bootstrap.php`.

--- a/docs/issues/CancelacionRetencionesError1308.md
+++ b/docs/issues/CancelacionRetencionesError1308.md
@@ -1,7 +1,7 @@
 # Cancelacion de Retenciones con error 1308
 
 Al momento de hacer pruebas de integración sobre el servicio de cancelación de CFDI de tipo retenciones e información
-de pagos, se encuentra que al enviar la solicitud el servidor de pruebas del SAT responde  en `CodEstatus` el
+de pagos, se encuentra que al enviar la solicitud el servidor de pruebas del SAT responde en `CodEstatus` el
 error `1308 - Certificado revocado o caduco`.
 
 Se ha reportado a Finkok con el [ticket #41610](https://support.finkok.com/support/tickets/41610) donde nos pudieron
@@ -9,13 +9,13 @@ responder ciertos cuestionamientos pero el problema sigue sin resolverse:
 
 - ¿Hay algún RFC en especial que deba utilizar para poder hacer pruebas de CFDI de retenciones y pagos?
 
-Como tal no existe un RFC en especifico, ya que se pueden realizar con los RFCs que se encuentran actualmente
-disponible para realizar pruebas, sin embargo en este momento el SAT no esta respondiendo de manera satisfactoria
-al utilizar cualquiera de los RFCs que se tienen publicados en el wiki y que ellos mismos proporcionaron.
+Como tal no existe un RFC en específico, ya que se pueden realizar con los RFC que se encuentran actualmente
+disponible para realizar pruebas, sin embargo en este momento el SAT no está respondiendo de manera satisfactoria
+al utilizar cualquiera de los RFC que se tienen publicados en el wiki y que ellos mismos proporcionaron.
 
-- ¿Porqué está devolviendo el código 1308?
+- ¿Por qué está devolviendo el código 1308?
 
-Al parecer la incidencia se presenta por que el SAT no tiene habilitados los RFCs de prueba.
+Al parecer la incidencia se presenta por que el SAT no tiene habilitados los RFC de prueba.
 
 - Si es un error del SAT, ¿se ha reportado?
 
@@ -23,7 +23,8 @@ Sí, sin embargo no hemos obtenido una respuesta favorable de su parte y en esto
 dando seguimiento al caso.
 
 - ¿Tienen ustedes pruebas de integración que confirmen que los servicios de pruebas del SAT están funcionando?
-En su momento cundo se implemento el método de cancelación de retenciones funcionaba de forma correcta sin embargo
+
+En su momento cuando se implementó el método de cancelación de retenciones funcionaba de forma correcta sin embargo
 debido a la actualización de los certificados de pruebas ya no fue posible efectuar pruebas de manera satisfactoria.
 De nuestra parte también hemos efectuado pruebas sin embargo obtenemos la misma respuesta que usted obtiene.
 
@@ -32,3 +33,5 @@ De nuestra parte también hemos efectuado pruebas sin embargo obtenemos la misma
 2020-01-24: Se encontró el problema y se obtuvo respuesta de las preguntas.
 
 2020-01-27: El problema persiste.
+
+2021-03-20: Las pruebas de integración ya no están marcando este problema.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,15 @@
+<?xml version="1.0"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
-         bootstrap="./tests/bootstrap.php" colors="true" cacheResult="false">
+        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+        bootstrap="./tests/bootstrap.php" colors="true" cacheResult="false">
     <testsuites>
         <testsuite name="Default">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <!-- exclude composer vendor folder -->
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src/</directory>
-        </whitelist>
-    </filter>
+  <coverage>
+      <include>
+          <directory suffix=".php">./src/</directory>
+      </include>
+  </coverage>
 </phpunit>

--- a/src/Definitions/Environment.php
+++ b/src/Definitions/Environment.php
@@ -15,6 +15,10 @@ use Eclipxe\Enum\Enum;
  */
 class Environment extends Enum
 {
+    /**
+     * @inheritdoc
+     * @noinspection PhpMissingParentCallCommonInspection
+     */
     protected static function overrideValues(): array
     {
         return [

--- a/src/Definitions/EnvironmentManifest.php
+++ b/src/Definitions/EnvironmentManifest.php
@@ -15,6 +15,10 @@ use Eclipxe\Enum\Enum;
  */
 class EnvironmentManifest extends Enum
 {
+    /**
+     * @inheritdoc
+     * @noinspection PhpMissingParentCallCommonInspection
+     */
     protected static function overrideValues(): array
     {
         return [

--- a/src/Definitions/ReceiptType.php
+++ b/src/Definitions/ReceiptType.php
@@ -12,6 +12,10 @@ use Eclipxe\Enum\Enum;
  */
 class ReceiptType extends Enum
 {
+    /**
+     * @inheritdoc
+     * @noinspection PhpMissingParentCallCommonInspection
+     */
     protected static function overrideValues(): array
     {
         return [

--- a/src/Definitions/Services.php
+++ b/src/Definitions/Services.php
@@ -23,6 +23,10 @@ use Eclipxe\Enum\Enum;
  */
 class Services extends Enum
 {
+    /**
+     * @inheritdoc
+     * @noinspection PhpMissingParentCallCommonInspection
+     */
     protected static function overrideValues(): array
     {
         return [

--- a/src/Definitions/SignedDocumentFormat.php
+++ b/src/Definitions/SignedDocumentFormat.php
@@ -14,6 +14,10 @@ use Eclipxe\Enum\Enum;
  */
 class SignedDocumentFormat extends Enum
 {
+    /**
+     * @inheritdoc
+     * @noinspection PhpMissingParentCallCommonInspection
+     */
     protected static function overrideValues(): array
     {
         return [

--- a/src/Finkok.php
+++ b/src/Finkok.php
@@ -121,7 +121,7 @@ class Finkok
      * @param mixed $command
      * @return object|null
      */
-    protected function checkCommand(string $method, $command)
+    protected function checkCommand(string $method, $command): ?object
     {
         $expected = static::SERVICES_MAP[$method][1];
         if ('' === $expected) {
@@ -140,7 +140,7 @@ class Finkok
      * @param string $method
      * @return object
      */
-    protected function createService(string $method)
+    protected function createService(string $method): object
     {
         $serviceClass = static::SERVICES_MAP[$method][0];
         $service = new $serviceClass($this->settings);

--- a/src/Finkok.php
+++ b/src/Finkok.php
@@ -110,8 +110,7 @@ class Finkok
         if (array_key_exists($name, static::SERVICES_MAP)) {
             $command = $this->checkCommand($name, $arguments[0] ?? null);
             $service = $this->createService($name);
-            $result = $this->executeService($name, $service, $command);
-            return $result;
+            return $this->executeService($name, $service, $command);
         }
         throw new BadMethodCallException(sprintf('Helper %s is not registered', $name));
     }
@@ -143,8 +142,7 @@ class Finkok
     protected function createService(string $method): object
     {
         $serviceClass = static::SERVICES_MAP[$method][0];
-        $service = new $serviceClass($this->settings);
-        return $service;
+        return new $serviceClass($this->settings);
     }
 
     /**

--- a/src/Helpers/GetSatStatusExtractor.php
+++ b/src/Helpers/GetSatStatusExtractor.php
@@ -10,6 +10,7 @@ use PhpCfdi\CfdiExpresiones\Exceptions\UnmatchedDocumentException;
 use PhpCfdi\CfdiExpresiones\Extractors\Comprobante32;
 use PhpCfdi\CfdiExpresiones\Extractors\Comprobante33;
 use PhpCfdi\Finkok\Services\Cancel\GetSatStatusCommand;
+use RuntimeException;
 
 /**
  * Based on a XML string or a XML Document it can extract the appropiate values to build a GetSatStatusCommand object
@@ -42,7 +43,7 @@ class GetSatStatusExtractor
             $values = $discoverer->obtain($document);
         } catch (UnmatchedDocumentException $exception) {
             $message = 'Unable to obtain the expression values, document must be valid a CFDI 3.3 or CFDI 3.2';
-            throw new \RuntimeException($message, 0, $exception);
+            throw new RuntimeException($message, 0, $exception);
         }
         return new self($values);
     }

--- a/src/Services/Cancel/AcceptRejectSignatureService.php
+++ b/src/Services/Cancel/AcceptRejectSignatureService.php
@@ -28,7 +28,6 @@ class AcceptRejectSignatureService
         $rawResponse = $soapCaller->call('accept_reject_signature', [
             'xml' => $command->xml(),
         ]);
-        $result = new AcceptRejectSignatureResult($rawResponse);
-        return $result;
+        return new AcceptRejectSignatureResult($rawResponse);
     }
 }

--- a/src/Services/Cancel/AcceptRejectUuidStatus.php
+++ b/src/Services/Cancel/AcceptRejectUuidStatus.php
@@ -21,7 +21,7 @@ final class AcceptRejectUuidStatus extends MicroCatalog
         ];
     }
 
-    public function getEntryValueOnUndefined()
+    public function getEntryValueOnUndefined(): string
     {
         return 'Respuesta del SAT desconocida';
     }

--- a/src/Services/Cancel/CancelSignatureService.php
+++ b/src/Services/Cancel/CancelSignatureService.php
@@ -29,7 +29,6 @@ class CancelSignatureService
             'xml' => $command->xml(),
             'store_pending' => $command->storePending()->asBool(),
         ]);
-        $result = new CancelSignatureResult($rawResponse);
-        return $result;
+        return new CancelSignatureResult($rawResponse);
     }
 }

--- a/src/Services/Registration/CustomerStatus.php
+++ b/src/Services/Registration/CustomerStatus.php
@@ -15,6 +15,10 @@ use Eclipxe\Enum\Enum;
  */
 class CustomerStatus extends Enum
 {
+    /**
+     * @inheritdoc
+     * @noinspection PhpMissingParentCallCommonInspection
+     */
     protected static function overrideValues(): array
     {
         return [

--- a/src/Services/Registration/CustomerType.php
+++ b/src/Services/Registration/CustomerType.php
@@ -15,6 +15,10 @@ use Eclipxe\Enum\Enum;
  */
 class CustomerType extends Enum
 {
+    /**
+     * @inheritdoc
+     * @noinspection PhpMissingParentCallCommonInspection
+     */
     protected static function overrideValues(): array
     {
         return [

--- a/src/Services/Retentions/CancelSignatureService.php
+++ b/src/Services/Retentions/CancelSignatureService.php
@@ -29,7 +29,6 @@ class CancelSignatureService
             'xml' => $command->xml(),
             'store_pending' => $command->storePending()->asBool(),
         ]);
-        $result = new CancelSignatureResult($rawResponse);
-        return $result;
+        return new CancelSignatureResult($rawResponse);
     }
 }

--- a/src/Services/Retentions/StampService.php
+++ b/src/Services/Retentions/StampService.php
@@ -28,7 +28,6 @@ class StampService
         $rawResponse = $soapCaller->call('stamp', [
             'xml' => $command->xml(),
         ]);
-        $result = new StampResult($rawResponse);
-        return $result;
+        return new StampResult($rawResponse);
     }
 }

--- a/src/Services/Retentions/StampedService.php
+++ b/src/Services/Retentions/StampedService.php
@@ -28,7 +28,6 @@ class StampedService
         $rawResponse = $soapCaller->call('stamped', [
             'xml' => $command->xml(),
         ]);
-        $result = new StampedResult($rawResponse);
-        return $result;
+        return new StampedResult($rawResponse);
     }
 }

--- a/src/Services/Stamping/QueryPendingService.php
+++ b/src/Services/Stamping/QueryPendingService.php
@@ -28,7 +28,6 @@ class QueryPendingService
         $rawResponse = $soapCaller->call('query_pending', [
             'uuid' => $command->uuid(),
         ]);
-        $result = new QueryPendingResult($rawResponse);
-        return $result;
+        return new QueryPendingResult($rawResponse);
     }
 }

--- a/src/Services/Stamping/QuickStampService.php
+++ b/src/Services/Stamping/QuickStampService.php
@@ -28,7 +28,6 @@ class QuickStampService
         $rawResponse = $soapCaller->call('quick_stamp', [
             'xml' => $command->xml(),
         ]);
-        $result = new StampingResult('quick_stampResult', $rawResponse);
-        return $result;
+        return new StampingResult('quick_stampResult', $rawResponse);
     }
 }

--- a/src/Services/Stamping/StampedService.php
+++ b/src/Services/Stamping/StampedService.php
@@ -28,7 +28,6 @@ class StampedService
         $rawResponse = $soapCaller->call('stamped', [
             'xml' => $command->xml(),
         ]);
-        $result = new StampingResult('stampedResult', $rawResponse);
-        return $result;
+        return new StampingResult('stampedResult', $rawResponse);
     }
 }

--- a/src/Services/Utilities/DatetimeService.php
+++ b/src/Services/Utilities/DatetimeService.php
@@ -31,7 +31,6 @@ class DatetimeService
         $rawResponse = $soapCaller->call('datetime', array_filter([
             'zipcode' => $command->postalCode(),
         ]));
-        $result = new DatetimeResult($rawResponse);
-        return $result;
+        return new DatetimeResult($rawResponse);
     }
 }

--- a/src/Services/Utilities/DatetimeService.php
+++ b/src/Services/Utilities/DatetimeService.php
@@ -22,11 +22,8 @@ class DatetimeService
         return $this->settings;
     }
 
-    public function datetime(DatetimeCommand $command = null): DatetimeResult
+    public function datetime(DatetimeCommand $command): DatetimeResult
     {
-        if (null === $command) {
-            $command = new DatetimeCommand('');
-        }
         $soapCaller = $this->settings()->createCallerForService(Services::utilities());
         $rawResponse = $soapCaller->call('datetime', array_filter([
             'zipcode' => $command->postalCode(),

--- a/src/SoapCaller.php
+++ b/src/SoapCaller.php
@@ -72,6 +72,7 @@ class SoapCaller implements LoggerAwareInterface
     /**
      * @param SoapClient $soapClient
      * @return array<string, string>
+     * @noinspection PhpUsageOfSilenceOperatorInspection
      */
     protected function extractSoapClientTrace(SoapClient $soapClient): array
     {

--- a/tests/Factories/PreCfdiCreatorHelper.php
+++ b/tests/Factories/PreCfdiCreatorHelper.php
@@ -11,7 +11,7 @@ use CfdiUtils\Utils\Rfc;
 use DateTimeImmutable;
 use DateTimeZone;
 
-class PreCfdiCreatorHelper
+final class PreCfdiCreatorHelper
 {
     /** @var DateTimeImmutable */
     private $invoiceDate;

--- a/tests/Factories/PreCfdiRetentionCreatorHelper.php
+++ b/tests/Factories/PreCfdiRetentionCreatorHelper.php
@@ -12,7 +12,7 @@ use CfdiUtils\Retenciones\RetencionesCreator10;
 use DateTimeImmutable;
 use DateTimeZone;
 
-class PreCfdiRetentionCreatorHelper
+final class PreCfdiRetentionCreatorHelper
 {
     /** @var Certificado */
     private $certificate;

--- a/tests/Factories/PreCfdiRetentionCreatorHelper.php
+++ b/tests/Factories/PreCfdiRetentionCreatorHelper.php
@@ -30,9 +30,6 @@ class PreCfdiRetentionCreatorHelper
     private $emisorName;
 
     /** @var string */
-    private $cerFile;
-
-    /** @var string */
     private $keyPemFile;
 
     /** @var string */
@@ -46,7 +43,6 @@ class PreCfdiRetentionCreatorHelper
         $this->certificate = new Certificado($cerFile);
         $this->emisorRfc = $this->certificate->getRfc();
         $this->emisorName = $this->certificate->getName();
-        $this->cerFile = $cerFile;
         $this->keyPemFile = $keyPemFile;
         $this->passPhrase = $passPhrase;
         $this->invoiceDate = new DateTimeImmutable('now -5 minutes', new DateTimeZone('America/Mexico_City'));

--- a/tests/Factories/RandomPreCfdi.php
+++ b/tests/Factories/RandomPreCfdi.php
@@ -8,7 +8,7 @@ use DateTimeImmutable;
 use DateTimeZone;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class RandomPreCfdi
+final class RandomPreCfdi
 {
     public function createDateFromString(string $dateExpression): DateTimeImmutable
     {

--- a/tests/Factories/RandomPreCfdiRetention.php
+++ b/tests/Factories/RandomPreCfdiRetention.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Factories;
 use DateTimeImmutable;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class RandomPreCfdiRetention
+final class RandomPreCfdiRetention
 {
     public function createValid(): string
     {

--- a/tests/Fakes/FakeSoapCaller.php
+++ b/tests/Fakes/FakeSoapCaller.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Fakes;
 use PhpCfdi\Finkok\SoapCaller;
 use stdClass;
 
-class FakeSoapCaller extends SoapCaller
+final class FakeSoapCaller extends SoapCaller
 {
     /** @var stdClass */
     public $preparedResult;
@@ -18,6 +18,7 @@ class FakeSoapCaller extends SoapCaller
     /** @var array<mixed> */
     public $latestCallParameters = [];
 
+    /** @noinspection PhpMissingParentCallCommonInspection */
     public function call(string $methodName, array $parameters): stdClass
     {
         $this->latestCallMethodName = $methodName;

--- a/tests/Fakes/FakeSoapFactory.php
+++ b/tests/Fakes/FakeSoapFactory.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\SoapFactory;
 use SoapClient;
 use stdClass;
 
-class FakeSoapFactory extends SoapFactory
+final class FakeSoapFactory extends SoapFactory
 {
     /** @var FakeSoapCaller */
     public $latestSoapCaller;
@@ -20,6 +20,7 @@ class FakeSoapFactory extends SoapFactory
     /** @var stdClass */
     public $preparedResult;
 
+    /** @noinspection PhpMissingParentCallCommonInspection */
     public function createSoapClient(string $wsdlLocation): SoapClient
     {
         return new SoapClient(null, [
@@ -28,6 +29,10 @@ class FakeSoapFactory extends SoapFactory
         ]);
     }
 
+    /**
+     * @inheritdoc
+     * @noinspection PhpMissingParentCallCommonInspection
+     */
     public function createSoapCaller(string $wsdlLocation, array $defaultOptions): SoapCaller
     {
         $soapCaller = new FakeSoapCaller($this->createSoapClient($wsdlLocation), $defaultOptions);

--- a/tests/Integration/FinkokTest.php
+++ b/tests/Integration/FinkokTest.php
@@ -6,7 +6,7 @@ namespace PhpCfdi\Finkok\Tests\Integration;
 
 use PhpCfdi\Finkok\Finkok;
 
-class FinkokTest extends IntegrationTestCase
+final class FinkokTest extends IntegrationTestCase
 {
     public function testCallingDateTime(): void
     {

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -22,10 +22,10 @@ use RuntimeException;
 abstract class IntegrationTestCase extends TestCase
 {
     /** @var StampingResult|null */
-    protected static $staticCurrentStampingResult = null;
+    protected static $staticCurrentStampingResult;
 
     /** @var StampingCommand|null */
-    protected static $staticCurrentStampingCommand = null;
+    protected static $staticCurrentStampingCommand;
 
     public function newStampingCommand(): StampingCommand
     {
@@ -83,8 +83,7 @@ abstract class IntegrationTestCase extends TestCase
     ): CancelSignatureCommand {
         $credential = $this->createCsdCredential();
         $signer = new CancelSigner([$uuid], $dateTime);
-        $command = new CancelSignatureCommand($signer->sign($credential));
-        return $command;
+        return new CancelSignatureCommand($signer->sign($credential));
     }
 
     protected function checkCanGetSatStatusOrFail(

--- a/tests/Integration/Services/Cancel/AcceptRejectSignatureServiceTest.php
+++ b/tests/Integration/Services/Cancel/AcceptRejectSignatureServiceTest.php
@@ -10,7 +10,7 @@ use PhpCfdi\Finkok\Services\Cancel\AcceptRejectSignatureCommand;
 use PhpCfdi\Finkok\Services\Cancel\AcceptRejectSignatureService;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
-class AcceptRejectSignatureServiceTest extends IntegrationTestCase
+final class AcceptRejectSignatureServiceTest extends IntegrationTestCase
 {
     protected function createService(): AcceptRejectSignatureService
     {

--- a/tests/Integration/Services/Cancel/CancelServicesTest.php
+++ b/tests/Integration/Services/Cancel/CancelServicesTest.php
@@ -51,8 +51,10 @@ final class CancelServicesTest extends IntegrationTestCase
             // do not try again if a SAT issue is **not** found
             // 708: Fink ok cannot connect to SAT
             // 300: SAT authentication cancellation service fail
+            // 305: SAT thinks "Certificado Inválido", it might be because incorrect time verification
             // 205: SAT does not have the uuid available for cancellation
-            if (! in_array($result->statusCode(), ['708', '300'], true) && '205' !== $document->documentStatus()) {
+            if (! in_array($result->statusCode(), ['708', '300', '305'], true)
+                && '205' !== $document->documentStatus()) {
                 break;
             }
             // do not try again if in the loop for more than allowed

--- a/tests/Integration/Services/Cancel/CancelServicesTest.php
+++ b/tests/Integration/Services/Cancel/CancelServicesTest.php
@@ -10,7 +10,7 @@ use PhpCfdi\Finkok\Services\Cancel\GetReceiptCommand;
 use PhpCfdi\Finkok\Services\Cancel\GetReceiptService;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
-class CancelServicesTest extends IntegrationTestCase
+final class CancelServicesTest extends IntegrationTestCase
 {
     public function testCreateCfdiThenGetSatStatusThenCancelSignatureThenGetReceipt(): void
     {

--- a/tests/Integration/Services/Cancel/CancelSignatureServiceTest.php
+++ b/tests/Integration/Services/Cancel/CancelSignatureServiceTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Integration\Services\Cancel;
 use PhpCfdi\Finkok\Services\Cancel\CancelSignatureService;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
-class CancelSignatureServiceTest extends IntegrationTestCase
+final class CancelSignatureServiceTest extends IntegrationTestCase
 {
     protected function createService(): CancelSignatureService
     {

--- a/tests/Integration/Services/Cancel/GetPendingServiceTest.php
+++ b/tests/Integration/Services/Cancel/GetPendingServiceTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Finkok\Services\Cancel\GetPendingCommand;
 use PhpCfdi\Finkok\Services\Cancel\GetPendingService;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
-class GetPendingServiceTest extends IntegrationTestCase
+final class GetPendingServiceTest extends IntegrationTestCase
 {
     public function testConsumeService(): void
     {

--- a/tests/Integration/Services/Cancel/GetReceiptServiceTest.php
+++ b/tests/Integration/Services/Cancel/GetReceiptServiceTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Services\Cancel\GetReceiptCommand;
 use PhpCfdi\Finkok\Services\Cancel\GetReceiptService;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
-class GetReceiptServiceTest extends IntegrationTestCase
+final class GetReceiptServiceTest extends IntegrationTestCase
 {
     protected function createService(): GetReceiptService
     {

--- a/tests/Integration/Services/Cancel/GetRelatedSignatureServiceTest.php
+++ b/tests/Integration/Services/Cancel/GetRelatedSignatureServiceTest.php
@@ -12,7 +12,7 @@ use PhpCfdi\Finkok\Services\Stamping\StampingCommand;
 use PhpCfdi\Finkok\Tests\Factories\RandomPreCfdi;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
-class GetRelatedSignatureServiceTest extends IntegrationTestCase
+final class GetRelatedSignatureServiceTest extends IntegrationTestCase
 {
     protected function createService(): GetRelatedSignatureService
     {

--- a/tests/Integration/Services/Cancel/GetSatStatusServiceTest.php
+++ b/tests/Integration/Services/Cancel/GetSatStatusServiceTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Finkok\Services\Cancel\GetSatStatusCommand;
 use PhpCfdi\Finkok\Services\Cancel\GetSatStatusService;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
-class GetSatStatusServiceTest extends IntegrationTestCase
+final class GetSatStatusServiceTest extends IntegrationTestCase
 {
     protected function createService(): GetSatStatusService
     {

--- a/tests/Integration/Services/Manifest/GetContractsServiceTest.php
+++ b/tests/Integration/Services/Manifest/GetContractsServiceTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Finkok\Services\Manifest\GetContractsCommand;
 use PhpCfdi\Finkok\Services\Manifest\GetContractsService;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
-class GetContractsServiceTest extends IntegrationTestCase
+final class GetContractsServiceTest extends IntegrationTestCase
 {
     private function createService(): GetContractsService
     {

--- a/tests/Integration/Services/Manifest/GetDocumentsSignSendAndGetSignedTest.php
+++ b/tests/Integration/Services/Manifest/GetDocumentsSignSendAndGetSignedTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Credentials\Credential;
 use PhpCfdi\Finkok\QuickFinkok;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
-class GetDocumentsSignSendAndGetSignedTest extends IntegrationTestCase
+final class GetDocumentsSignSendAndGetSignedTest extends IntegrationTestCase
 {
     private function createFielCredential(): Credential
     {

--- a/tests/Integration/Services/Manifest/GetSignedContractsServiceTest.php
+++ b/tests/Integration/Services/Manifest/GetSignedContractsServiceTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Services\Manifest\GetSignedContractsCommand;
 use PhpCfdi\Finkok\Services\Manifest\GetSignedContractsService;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
-class GetSignedContractsServiceTest extends IntegrationTestCase
+final class GetSignedContractsServiceTest extends IntegrationTestCase
 {
     private function createService(): GetSignedContractsService
     {

--- a/tests/Integration/Services/Manifest/SignContractsServiceTest.php
+++ b/tests/Integration/Services/Manifest/SignContractsServiceTest.php
@@ -13,7 +13,7 @@ use PhpCfdi\Finkok\Services\Manifest\SignContractsResult;
 use PhpCfdi\Finkok\Services\Manifest\SignContractsService;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
-class SignContractsServiceTest extends IntegrationTestCase
+final class SignContractsServiceTest extends IntegrationTestCase
 {
     private function consumeSignContracts(
         string $rfc,

--- a/tests/Integration/Services/Registration/AddServiceTest.php
+++ b/tests/Integration/Services/Registration/AddServiceTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Services\Registration\AddCommand;
 use PhpCfdi\Finkok\Services\Registration\AddService;
 use PhpCfdi\Finkok\Services\Registration\CustomerType;
 
-class AddServiceTest extends RegistrationIntegrationTestCase
+final class AddServiceTest extends RegistrationIntegrationTestCase
 {
     protected function createService(): AddService
     {

--- a/tests/Integration/Services/Registration/AssignServiceTest.php
+++ b/tests/Integration/Services/Registration/AssignServiceTest.php
@@ -11,7 +11,7 @@ use PhpCfdi\Finkok\Services\Registration\CustomerType;
 use PhpCfdi\Finkok\Services\Registration\SwitchCommand;
 use PhpCfdi\Finkok\Services\Registration\SwitchService;
 
-class AssignServiceTest extends RegistrationIntegrationTestCase
+final class AssignServiceTest extends RegistrationIntegrationTestCase
 {
     protected function staticSettings(): FinkokSettings
     {

--- a/tests/Integration/Services/Registration/EditServiceTest.php
+++ b/tests/Integration/Services/Registration/EditServiceTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Finkok\Services\Registration\CustomerStatus;
 use PhpCfdi\Finkok\Services\Registration\EditCommand;
 use PhpCfdi\Finkok\Services\Registration\EditService;
 
-class EditServiceTest extends RegistrationIntegrationTestCase
+final class EditServiceTest extends RegistrationIntegrationTestCase
 {
     protected function createService(): EditService
     {

--- a/tests/Integration/Services/Registration/EditServiceTest.php
+++ b/tests/Integration/Services/Registration/EditServiceTest.php
@@ -12,8 +12,7 @@ class EditServiceTest extends RegistrationIntegrationTestCase
 {
     protected function createService(): EditService
     {
-        $editService = new EditService($this->createSettingsFromEnvironment());
-        return $editService;
+        return new EditService($this->createSettingsFromEnvironment());
     }
 
     public function testConsumeEditServiceUsingExistentRfc(): void

--- a/tests/Integration/Services/Registration/ObtainServiceTest.php
+++ b/tests/Integration/Services/Registration/ObtainServiceTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Integration\Services\Registration;
 use PhpCfdi\Finkok\Services\Registration\ObtainCommand;
 use PhpCfdi\Finkok\Services\Registration\ObtainService;
 
-class ObtainServiceTest extends RegistrationIntegrationTestCase
+final class ObtainServiceTest extends RegistrationIntegrationTestCase
 {
     protected function createService(): ObtainService
     {

--- a/tests/Integration/Services/Registration/SwitchServiceTest.php
+++ b/tests/Integration/Services/Registration/SwitchServiceTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Finkok\Services\Registration\CustomerType;
 use PhpCfdi\Finkok\Services\Registration\SwitchCommand;
 use PhpCfdi\Finkok\Services\Registration\SwitchService;
 
-class SwitchServiceTest extends RegistrationIntegrationTestCase
+final class SwitchServiceTest extends RegistrationIntegrationTestCase
 {
     protected function createService(): SwitchService
     {

--- a/tests/Integration/Services/Retentions/CancelSignatureServiceTest.php
+++ b/tests/Integration/Services/Retentions/CancelSignatureServiceTest.php
@@ -55,9 +55,6 @@ final class CancelSignatureServiceTest extends RetentionsTestCase
         $uuid = 'AAB81A24-8CD8-4703-A2CE-88F4E98E8044';
         $result = $this->quickFinkok->retentionCancel($this->createCsdCredential(), $uuid);
         echo json_encode($result->rawData(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
-        if ('1308' === $result->statusCode()) {
-            $this->markTestSkipped('Finkok ticket #41610, SAT error: Certificado revocado o caduco');
-        }
         $this->assertSame($uuid, $result->documents()->first()->uuid(), 'Cancelled UUID must match with requested');
     }
 }

--- a/tests/Integration/Services/Retentions/RetentionsUsingExistentRetentionTest.php
+++ b/tests/Integration/Services/Retentions/RetentionsUsingExistentRetentionTest.php
@@ -24,18 +24,18 @@ final class RetentionsUsingExistentRetentionTest extends RetentionsTestCase
 
     protected function currentRetentionsPreCfdi(): string
     {
-        if (null === static::$staticCurrentStampPrecfdi) {
-            static::$staticCurrentStampPrecfdi = $this->newRetentionsPreCfdi();
+        if (null === self::$staticCurrentStampPrecfdi) {
+            self::$staticCurrentStampPrecfdi = $this->newRetentionsPreCfdi();
         }
-        return static::$staticCurrentStampPrecfdi;
+        return self::$staticCurrentStampPrecfdi;
     }
 
     protected function currentRetentionsStampResult(): StampResult
     {
-        if (null === static::$staticCurrentStampResult) {
-            static::$staticCurrentStampResult = $this->stampRetentionPreCfdi($this->currentRetentionsPreCfdi());
+        if (null === self::$staticCurrentStampResult) {
+            self::$staticCurrentStampResult = $this->stampRetentionPreCfdi($this->currentRetentionsPreCfdi());
         }
-        return static::$staticCurrentStampResult;
+        return self::$staticCurrentStampResult;
     }
 
     protected function setUp(): void

--- a/tests/Integration/Services/Stamping/QueryPendingServiceTest.php
+++ b/tests/Integration/Services/Stamping/QueryPendingServiceTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Finkok\Services\Stamping\QueryPendingCommand;
 use PhpCfdi\Finkok\Services\Stamping\QueryPendingService;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
-class QueryPendingServiceTest extends IntegrationTestCase
+final class QueryPendingServiceTest extends IntegrationTestCase
 {
     protected function createService(): QueryPendingService
     {

--- a/tests/Integration/Services/Stamping/QuickStampServiceTest.php
+++ b/tests/Integration/Services/Stamping/QuickStampServiceTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Integration\Services\Stamping;
 use PhpCfdi\Finkok\Services\Stamping\QuickStampService;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
-class QuickStampServiceTest extends IntegrationTestCase
+final class QuickStampServiceTest extends IntegrationTestCase
 {
     protected function createService(): QuickStampService
     {

--- a/tests/Integration/Services/Stamping/StampServiceTest.php
+++ b/tests/Integration/Services/Stamping/StampServiceTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Integration\Services\Stamping;
 use PhpCfdi\Finkok\Services\Stamping\StampService;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
-class StampServiceTest extends IntegrationTestCase
+final class StampServiceTest extends IntegrationTestCase
 {
     protected function createService(): StampService
     {

--- a/tests/Integration/Services/Stamping/StampedServiceTest.php
+++ b/tests/Integration/Services/Stamping/StampedServiceTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Integration\Services\Stamping;
 use PhpCfdi\Finkok\Services\Stamping\StampedService;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
-class StampedServiceTest extends IntegrationTestCase
+final class StampedServiceTest extends IntegrationTestCase
 {
     protected function createService(): StampedService
     {

--- a/tests/Integration/Services/Utilities/DatetimeServiceTest.php
+++ b/tests/Integration/Services/Utilities/DatetimeServiceTest.php
@@ -7,6 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Integration\Services\Utilities;
 use PhpCfdi\Finkok\FinkokEnvironment;
 use PhpCfdi\Finkok\FinkokSettings;
 use PhpCfdi\Finkok\QuickFinkok;
+use PhpCfdi\Finkok\Services\Utilities\DatetimeCommand;
 use PhpCfdi\Finkok\Services\Utilities\DatetimeService;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
@@ -31,7 +32,7 @@ final class DatetimeServiceTest extends IntegrationTestCase
     {
         $settings = $this->createSettingsFromEnvironment();
         $service = new DatetimeService($settings);
-        $result = $service->datetime();
+        $result = $service->datetime(new DatetimeCommand(''));
 
         $this->assertMatchesRegularExpression('/^[\d:T\-]{19}$/', $result->datetime());
         /** @var int|false $converted */
@@ -56,7 +57,7 @@ final class DatetimeServiceTest extends IntegrationTestCase
             FinkokEnvironment::makeDevelopment()
         );
         $service = new DatetimeService($settings);
-        $result = $service->datetime();
+        $result = $service->datetime(new DatetimeCommand(''));
         $this->assertSame('Invalid username or password', $result->error());
     }
 }

--- a/tests/Integration/Services/Utilities/DatetimeServiceTest.php
+++ b/tests/Integration/Services/Utilities/DatetimeServiceTest.php
@@ -10,7 +10,7 @@ use PhpCfdi\Finkok\QuickFinkok;
 use PhpCfdi\Finkok\Services\Utilities\DatetimeService;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
-class DatetimeServiceTest extends IntegrationTestCase
+final class DatetimeServiceTest extends IntegrationTestCase
 {
     public function testTwoWellKnownDifferentPostalCodes(): void
     {

--- a/tests/Integration/Services/Utilities/DatetimeServiceTest.php
+++ b/tests/Integration/Services/Utilities/DatetimeServiceTest.php
@@ -33,7 +33,7 @@ final class DatetimeServiceTest extends IntegrationTestCase
         $service = new DatetimeService($settings);
         $result = $service->datetime();
 
-        $this->assertRegExp('/^[\d:T\-]{19}$/', $result->datetime());
+        $this->assertMatchesRegularExpression('/^[\d:T\-]{19}$/', $result->datetime());
         /** @var int|false $converted */
         $converted = strtotime($result->datetime());
         if (false === $converted) {

--- a/tests/Integration/Services/Utilities/DownloadXmlServiceTest.php
+++ b/tests/Integration/Services/Utilities/DownloadXmlServiceTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Finkok\Services\Utilities\DownloadXmlCommand;
 use PhpCfdi\Finkok\Services\Utilities\DownloadXmlService;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
-class DownloadXmlServiceTest extends IntegrationTestCase
+final class DownloadXmlServiceTest extends IntegrationTestCase
 {
     protected function createService(): DownloadXmlService
     {

--- a/tests/Integration/Services/Utilities/ReportCreditServiceTest.php
+++ b/tests/Integration/Services/Utilities/ReportCreditServiceTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Services\Utilities\ReportCreditResult;
 use PhpCfdi\Finkok\Services\Utilities\ReportCreditService;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
-class ReportCreditServiceTest extends IntegrationTestCase
+final class ReportCreditServiceTest extends IntegrationTestCase
 {
     public function testReportCreditService(): void
     {

--- a/tests/Integration/Services/Utilities/ReportTotalServiceTest.php
+++ b/tests/Integration/Services/Utilities/ReportTotalServiceTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Services\Utilities\ReportTotalCommand;
 use PhpCfdi\Finkok\Services\Utilities\ReportTotalService;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
-class ReportTotalServiceTest extends IntegrationTestCase
+final class ReportTotalServiceTest extends IntegrationTestCase
 {
     public function testReportTotalServiceInPast(): void
     {

--- a/tests/Integration/Services/Utilities/ReportUuidServiceTest.php
+++ b/tests/Integration/Services/Utilities/ReportUuidServiceTest.php
@@ -10,7 +10,7 @@ use PhpCfdi\Finkok\Services\Utilities\ReportUuidResult;
 use PhpCfdi\Finkok\Services\Utilities\ReportUuidService;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
-class ReportUuidServiceTest extends IntegrationTestCase
+final class ReportUuidServiceTest extends IntegrationTestCase
 {
     public function testReportUuidService(): void
     {

--- a/tests/LoggerPrinter.php
+++ b/tests/LoggerPrinter.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
 
-class LoggerPrinter extends AbstractLogger implements LoggerInterface
+final class LoggerPrinter extends AbstractLogger implements LoggerInterface
 {
     /** @var string */
     public $outputFile;

--- a/tests/Unit/Definitions/EnvironmentTest.php
+++ b/tests/Unit/Definitions/EnvironmentTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Definitions;
 use PhpCfdi\Finkok\Definitions\Environment;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class EnvironmentTest extends TestCase
+final class EnvironmentTest extends TestCase
 {
     public function testContainsDevelopmentValue(): void
     {

--- a/tests/Unit/Exceptions/InvalidArgumentExceptionTest.php
+++ b/tests/Unit/Exceptions/InvalidArgumentExceptionTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Finkok\Exceptions\FinkokException;
 use PhpCfdi\Finkok\Exceptions\InvalidArgumentException;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class InvalidArgumentExceptionTest extends TestCase
+final class InvalidArgumentExceptionTest extends TestCase
 {
     public function testIsInstaceOfFinkokException(): void
     {

--- a/tests/Unit/FinkokEnvironmentTest.php
+++ b/tests/Unit/FinkokEnvironmentTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Definitions\Services;
 use PhpCfdi\Finkok\FinkokEnvironment;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class FinkokEnvironmentTest extends TestCase
+final class FinkokEnvironmentTest extends TestCase
 {
     public function testConstructDevelopment(): void
     {

--- a/tests/Unit/FinkokSettingsTest.php
+++ b/tests/Unit/FinkokSettingsTest.php
@@ -11,7 +11,7 @@ use PhpCfdi\Finkok\FinkokSettings;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class FinkokSettingsTest extends TestCase
+final class FinkokSettingsTest extends TestCase
 {
     public function testConstructWithUsernameAndPassword(): void
     {

--- a/tests/Unit/FinkokTest.php
+++ b/tests/Unit/FinkokTest.php
@@ -109,9 +109,9 @@ class FinkokTest extends TestCase
     {
         /** @var FinkokSettings&MockObject $settings */
         $settings = $this->createMock(FinkokSettings::class);
-        // extend just to change change method visibility
+        // extend just to access protected method
         $finkok = new class($settings) extends Finkok {
-            public function executeService(string $method, object $service, ?object $command)
+            public function exposedExecuteService(string $method, object $service, ?object $command)
             {
                 return parent::executeService($method, $service, $command);
             }
@@ -124,7 +124,7 @@ class FinkokTest extends TestCase
 
         $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessageMatches('/The service \w+ does not have a method foo$/');
-        $finkok->executeService('foo', $service, $command);
+        $finkok->exposedExecuteService('foo', $service, $command);
     }
 
     public function testInvokingOneMappedMagicMethodWithDifferentName(): void

--- a/tests/Unit/FinkokTest.php
+++ b/tests/Unit/FinkokTest.php
@@ -19,7 +19,7 @@ use PhpCfdi\Finkok\Services\Utilities\DatetimeService;
 use PhpCfdi\Finkok\Tests\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
-class FinkokTest extends TestCase
+final class FinkokTest extends TestCase
 {
     public function testConstructor(): void
     {
@@ -109,8 +109,15 @@ class FinkokTest extends TestCase
     {
         /** @var FinkokSettings&MockObject $settings */
         $settings = $this->createMock(FinkokSettings::class);
-        // extend just to access protected method
         $finkok = new class($settings) extends Finkok {
+            /**
+             * created just to access protected method
+             *
+             * @param string $method
+             * @param object $service
+             * @param object|null $command
+             * @return mixed
+             */
             public function exposedExecuteService(string $method, object $service, ?object $command)
             {
                 return parent::executeService($method, $service, $command);

--- a/tests/Unit/Helpers/AcceptRejectSignerTest.php
+++ b/tests/Unit/Helpers/AcceptRejectSignerTest.php
@@ -10,7 +10,7 @@ use PhpCfdi\Finkok\Helpers\AcceptRejectSigner;
 
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class AcceptRejectSignerTest extends TestCase
+final class AcceptRejectSignerTest extends TestCase
 {
     public function testCreateAndSign(): void
     {

--- a/tests/Unit/Helpers/CancelSignerTest.php
+++ b/tests/Unit/Helpers/CancelSignerTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Helpers\CancelSigner;
 
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class CancelSignerTest extends TestCase
+final class CancelSignerTest extends TestCase
 {
     public function testCreateAndSign(): void
     {

--- a/tests/Unit/Helpers/DocumentSignerTest.php
+++ b/tests/Unit/Helpers/DocumentSignerTest.php
@@ -12,7 +12,7 @@ use PhpCfdi\Finkok\Helpers\DocumentSigner;
 
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class DocumentSignerTest extends TestCase
+final class DocumentSignerTest extends TestCase
 {
     public function testCreateDocumentSigner(): void
     {

--- a/tests/Unit/Helpers/GetRelatedSignerTest.php
+++ b/tests/Unit/Helpers/GetRelatedSignerTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Helpers\GetRelatedSigner;
 
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class GetRelatedSignerTest extends TestCase
+final class GetRelatedSignerTest extends TestCase
 {
     public function testCreateAndSign(): void
     {

--- a/tests/Unit/Helpers/GetSatStatusExtractorTest.php
+++ b/tests/Unit/Helpers/GetSatStatusExtractorTest.php
@@ -6,8 +6,9 @@ namespace PhpCfdi\Finkok\Tests\Unit\Helpers;
 
 use PhpCfdi\Finkok\Helpers\GetSatStatusExtractor;
 use PhpCfdi\Finkok\Tests\TestCase;
+use RuntimeException;
 
-class GetSatStatusExtractorTest extends TestCase
+final class GetSatStatusExtractorTest extends TestCase
 {
     public function testConstructWithEmptyData(): void
     {
@@ -44,7 +45,7 @@ EOT;
     public function testConstructWithOtherXml(): void
     {
         $fakeCfdi = '<xml/>';
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Unable to obtain the expression values');
         GetSatStatusExtractor::fromXmlString($fakeCfdi);
     }

--- a/tests/Unit/QuickFinkokTest.php
+++ b/tests/Unit/QuickFinkokTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\Finkok\Tests\Unit;
 
+use DateTimeImmutable;
 use PhpCfdi\Finkok\Definitions\CancelAnswer;
 use PhpCfdi\Finkok\Definitions\RfcRole;
 use PhpCfdi\Finkok\QuickFinkok;
@@ -17,7 +18,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
 
 /** @covers \PhpCfdi\Finkok\QuickFinkok */
-class QuickFinkokTest extends TestCase
+final class QuickFinkokTest extends TestCase
 {
     /** @var FakeSoapFactory */
     private $soapFactory;
@@ -228,7 +229,7 @@ EOT;
         $rawData = json_decode($this->fileContentPath('utilities-report-uuid-response.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
 
-        $since = new \DateTimeImmutable('2019-01-13 00:00:00');
+        $since = new DateTimeImmutable('2019-01-13 00:00:00');
         $until = $since->modify('+1 day -1 second');
         $result = $finkok->reportUuids('x-rfc', $since, $until);
 
@@ -399,7 +400,7 @@ EOT;
                 $this->stringContains($getContractsResult->contract())
             );
 
-        $signedOn = new \DateTimeImmutable('2019-01-13 14:15:16');
+        $signedOn = new DateTimeImmutable('2019-01-13 14:15:16');
         $finkok->customerSignAndSendContracts($fiel, 'x-snid', 'x-address', 'x-email', $signedOn);
     }
 

--- a/tests/Unit/QuickFinkokTest.php
+++ b/tests/Unit/QuickFinkokTest.php
@@ -28,8 +28,7 @@ class QuickFinkokTest extends TestCase
         $fakeFactory->preparedResult = $rawData;
         $settings = $this->createSettingsFromEnvironment($fakeFactory);
         $this->soapFactory = $fakeFactory;
-        $finkok = new QuickFinkok($settings);
-        return $finkok;
+        return new QuickFinkok($settings);
     }
 
     /**

--- a/tests/Unit/Services/AbstractResultTest.php
+++ b/tests/Unit/Services/AbstractResultTest.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 use PhpCfdi\Finkok\Tests\TestCase;
 use stdClass;
 
-class AbstractResultTest extends TestCase
+final class AbstractResultTest extends TestCase
 {
     /** @var stdClass */
     private $data;
@@ -50,6 +50,7 @@ class AbstractResultTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unable to find mean object at /other');
+        /** @noinspection PhpExpressionResultUnusedInspection */
         new TestingResult($this->data, 'other');
     }
 

--- a/tests/Unit/Services/Cancel/AcceptRejectSignatureCommandTest.php
+++ b/tests/Unit/Services/Cancel/AcceptRejectSignatureCommandTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Cancel;
 use PhpCfdi\Finkok\Services\Cancel\AcceptRejectSignatureCommand;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class AcceptRejectSignatureCommandTest extends TestCase
+final class AcceptRejectSignatureCommandTest extends TestCase
 {
     public function testCommandValues(): void
     {

--- a/tests/Unit/Services/Cancel/AcceptRejectSignatureResultTest.php
+++ b/tests/Unit/Services/Cancel/AcceptRejectSignatureResultTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Cancel;
 use PhpCfdi\Finkok\Services\Cancel\AcceptRejectSignatureResult;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class AcceptRejectSignatureResultTest extends TestCase
+final class AcceptRejectSignatureResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponse(): void
     {

--- a/tests/Unit/Services/Cancel/AcceptRejectSignatureServiceTest.php
+++ b/tests/Unit/Services/Cancel/AcceptRejectSignatureServiceTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Services\Cancel\AcceptRejectSignatureService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class AcceptRejectSignatureServiceTest extends TestCase
+final class AcceptRejectSignatureServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {

--- a/tests/Unit/Services/Cancel/AcceptRejectUuidItemTest.php
+++ b/tests/Unit/Services/Cancel/AcceptRejectUuidItemTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Services\Cancel\AcceptRejectUuidItem;
 use PhpCfdi\Finkok\Services\Cancel\AcceptRejectUuidStatus;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class AcceptRejectUuidItemTest extends TestCase
+final class AcceptRejectUuidItemTest extends TestCase
 {
     public function testCreateAndGetProperties(): void
     {

--- a/tests/Unit/Services/Cancel/AcceptRejectUuidListTest.php
+++ b/tests/Unit/Services/Cancel/AcceptRejectUuidListTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Definitions\CancelAnswer;
 use PhpCfdi\Finkok\Services\Cancel\AcceptRejectUuidList;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class AcceptRejectUuidListTest extends TestCase
+final class AcceptRejectUuidListTest extends TestCase
 {
     /** @var AcceptRejectUuidList */
     private $list;

--- a/tests/Unit/Services/Cancel/AcceptRejectUuidStatusTest.php
+++ b/tests/Unit/Services/Cancel/AcceptRejectUuidStatusTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Cancel;
 use PhpCfdi\Finkok\Services\Cancel\AcceptRejectUuidStatus;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class AcceptRejectUuidStatusTest extends TestCase
+final class AcceptRejectUuidStatusTest extends TestCase
 {
     public function testCreateSuccessStatus(): void
     {

--- a/tests/Unit/Services/Cancel/CancelSignatureCommandTest.php
+++ b/tests/Unit/Services/Cancel/CancelSignatureCommandTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Finkok\Definitions\CancelStorePending;
 use PhpCfdi\Finkok\Services\Cancel\CancelSignatureCommand;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class CancelSignatureCommandTest extends TestCase
+final class CancelSignatureCommandTest extends TestCase
 {
     public function testCommandDefaultValue(): void
     {

--- a/tests/Unit/Services/Cancel/CancelSignatureResultTest.php
+++ b/tests/Unit/Services/Cancel/CancelSignatureResultTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Cancel;
 use PhpCfdi\Finkok\Services\Cancel\CancelSignatureResult;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class CancelSignatureResultTest extends TestCase
+final class CancelSignatureResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponses(): void
     {

--- a/tests/Unit/Services/Cancel/CancelSignatureServiceTest.php
+++ b/tests/Unit/Services/Cancel/CancelSignatureServiceTest.php
@@ -10,7 +10,7 @@ use PhpCfdi\Finkok\Services\Cancel\CancelSignatureService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class CancelSignatureServiceTest extends TestCase
+final class CancelSignatureServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {

--- a/tests/Unit/Services/Cancel/CancelledDocumentTest.php
+++ b/tests/Unit/Services/Cancel/CancelledDocumentTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Cancel;
 use PhpCfdi\Finkok\Services\Cancel\CancelledDocument;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class CancelledDocumentTest extends TestCase
+final class CancelledDocumentTest extends TestCase
 {
     public function testCreateEmpty(): void
     {

--- a/tests/Unit/Services/Cancel/CancelledDocumentsTest.php
+++ b/tests/Unit/Services/Cancel/CancelledDocumentsTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Cancel;
 use PhpCfdi\Finkok\Services\Cancel\CancelledDocuments;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class CancelledDocumentsTest extends TestCase
+final class CancelledDocumentsTest extends TestCase
 {
     protected function createCancelledDocuments(): CancelledDocuments
     {

--- a/tests/Unit/Services/Cancel/CancelledDocumentsTest.php
+++ b/tests/Unit/Services/Cancel/CancelledDocumentsTest.php
@@ -23,9 +23,7 @@ class CancelledDocumentsTest extends TestCase
                 'EstatusCancelacion' => 'Cancelado sin aceptación',
             ],
         ];
-
-        $documents = new CancelledDocuments($input);
-        return $documents;
+        return new CancelledDocuments($input);
     }
 
     protected function createTestingUuid(int $index): string

--- a/tests/Unit/Services/Cancel/GetPendingCommandTest.php
+++ b/tests/Unit/Services/Cancel/GetPendingCommandTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Cancel;
 use PhpCfdi\Finkok\Services\Cancel\GetPendingCommand;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class GetPendingCommandTest extends TestCase
+final class GetPendingCommandTest extends TestCase
 {
     public function testCommandValues(): void
     {

--- a/tests/Unit/Services/Cancel/GetPendingResultTest.php
+++ b/tests/Unit/Services/Cancel/GetPendingResultTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Cancel;
 use PhpCfdi\Finkok\Services\Cancel\GetPendingResult;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class GetPendingResultTest extends TestCase
+final class GetPendingResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponse(): void
     {

--- a/tests/Unit/Services/Cancel/GetPendingServiceTest.php
+++ b/tests/Unit/Services/Cancel/GetPendingServiceTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Services\Cancel\GetPendingService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class GetPendingServiceTest extends TestCase
+final class GetPendingServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {

--- a/tests/Unit/Services/Cancel/GetReceiptCommandTest.php
+++ b/tests/Unit/Services/Cancel/GetReceiptCommandTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Finkok\Definitions\ReceiptType;
 use PhpCfdi\Finkok\Services\Cancel\GetReceiptCommand;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class GetReceiptCommandTest extends TestCase
+final class GetReceiptCommandTest extends TestCase
 {
     public function testCommandValues(): void
     {

--- a/tests/Unit/Services/Cancel/GetReceiptResultTest.php
+++ b/tests/Unit/Services/Cancel/GetReceiptResultTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Cancel;
 use PhpCfdi\Finkok\Services\Cancel\GetReceiptResult;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class GetReceiptResultTest extends TestCase
+final class GetReceiptResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponse(): void
     {

--- a/tests/Unit/Services/Cancel/GetReceiptServiceTest.php
+++ b/tests/Unit/Services/Cancel/GetReceiptServiceTest.php
@@ -10,7 +10,7 @@ use PhpCfdi\Finkok\Services\Cancel\GetReceiptService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class GetReceiptServiceTest extends TestCase
+final class GetReceiptServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {

--- a/tests/Unit/Services/Cancel/GetRelatedSignatureCommandTest.php
+++ b/tests/Unit/Services/Cancel/GetRelatedSignatureCommandTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Cancel;
 use PhpCfdi\Finkok\Services\Cancel\GetRelatedSignatureCommand;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class GetRelatedSignatureCommandTest extends TestCase
+final class GetRelatedSignatureCommandTest extends TestCase
 {
     public function testCommandValues(): void
     {

--- a/tests/Unit/Services/Cancel/GetRelatedSignatureResultTest.php
+++ b/tests/Unit/Services/Cancel/GetRelatedSignatureResultTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Cancel;
 use PhpCfdi\Finkok\Services\Cancel\GetRelatedSignatureResult;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class GetRelatedSignatureResultTest extends TestCase
+final class GetRelatedSignatureResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponse(): void
     {

--- a/tests/Unit/Services/Cancel/GetRelatedSignatureServiceTest.php
+++ b/tests/Unit/Services/Cancel/GetRelatedSignatureServiceTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Services\Cancel\GetRelatedSignatureService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class GetRelatedSignatureServiceTest extends TestCase
+final class GetRelatedSignatureServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {

--- a/tests/Unit/Services/Cancel/GetSatStatusCommandTest.php
+++ b/tests/Unit/Services/Cancel/GetSatStatusCommandTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Cancel;
 use PhpCfdi\Finkok\Services\Cancel\GetSatStatusCommand;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class GetSatStatusCommandTest extends TestCase
+final class GetSatStatusCommandTest extends TestCase
 {
     public function testCommandValues(): void
     {

--- a/tests/Unit/Services/Cancel/GetSatStatusResultTest.php
+++ b/tests/Unit/Services/Cancel/GetSatStatusResultTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Cancel;
 use PhpCfdi\Finkok\Services\Cancel\GetSatStatusResult;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class GetSatStatusResultTest extends TestCase
+final class GetSatStatusResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponse(): void
     {

--- a/tests/Unit/Services/Cancel/GetSatStatusServiceTest.php
+++ b/tests/Unit/Services/Cancel/GetSatStatusServiceTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Services\Cancel\GetSatStatusService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class GetSatStatusServiceTest extends TestCase
+final class GetSatStatusServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {

--- a/tests/Unit/Services/Manifest/GetContractsCommandTest.php
+++ b/tests/Unit/Services/Manifest/GetContractsCommandTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Manifest;
 use PhpCfdi\Finkok\Services\Manifest\GetContractsCommand;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class GetContractsCommandTest extends TestCase
+final class GetContractsCommandTest extends TestCase
 {
     public function testCreateCommand(): void
     {

--- a/tests/Unit/Services/Manifest/GetContractsResultTest.php
+++ b/tests/Unit/Services/Manifest/GetContractsResultTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Manifest;
 use PhpCfdi\Finkok\Services\Manifest\GetContractsResult;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class GetContractsResultTest extends TestCase
+final class GetContractsResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponses(): void
     {

--- a/tests/Unit/Services/Manifest/GetContractsServiceTest.php
+++ b/tests/Unit/Services/Manifest/GetContractsServiceTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Services\Manifest\GetContractsService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class GetContractsServiceTest extends TestCase
+final class GetContractsServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {

--- a/tests/Unit/Services/Manifest/GetSignedContractsCommandTest.php
+++ b/tests/Unit/Services/Manifest/GetSignedContractsCommandTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Finkok\Definitions\SignedDocumentFormat;
 use PhpCfdi\Finkok\Services\Manifest\GetSignedContractsCommand;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class GetSignedContractsCommandTest extends TestCase
+final class GetSignedContractsCommandTest extends TestCase
 {
     public function testCreateCommand(): void
     {

--- a/tests/Unit/Services/Manifest/GetSignedContractsResultTest.php
+++ b/tests/Unit/Services/Manifest/GetSignedContractsResultTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Manifest;
 use PhpCfdi\Finkok\Services\Manifest\GetSignedContractsResult;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class GetSignedContractsResultTest extends TestCase
+final class GetSignedContractsResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponses(): void
     {

--- a/tests/Unit/Services/Manifest/GetSignedContractsServiceTest.php
+++ b/tests/Unit/Services/Manifest/GetSignedContractsServiceTest.php
@@ -10,7 +10,7 @@ use PhpCfdi\Finkok\Services\Manifest\GetSignedContractsService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class GetSignedContractsServiceTest extends TestCase
+final class GetSignedContractsServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {

--- a/tests/Unit/Services/Manifest/SignContractsCommandTest.php
+++ b/tests/Unit/Services/Manifest/SignContractsCommandTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Manifest;
 use PhpCfdi\Finkok\Services\Manifest\SignContractsCommand;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class SignContractsCommandTest extends TestCase
+final class SignContractsCommandTest extends TestCase
 {
     public function testCreateCommand(): void
     {

--- a/tests/Unit/Services/Manifest/SignContractsResultTest.php
+++ b/tests/Unit/Services/Manifest/SignContractsResultTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Manifest;
 use PhpCfdi\Finkok\Services\Manifest\SignContractsResult;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class SignContractsResultTest extends TestCase
+final class SignContractsResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponses(): void
     {

--- a/tests/Unit/Services/Manifest/SignContractsServiceTest.php
+++ b/tests/Unit/Services/Manifest/SignContractsServiceTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Services\Manifest\SignContractsService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class SignContractsServiceTest extends TestCase
+final class SignContractsServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {

--- a/tests/Unit/Services/Registration/AddCommandTest.php
+++ b/tests/Unit/Services/Registration/AddCommandTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Finkok\Services\Registration\AddCommand;
 use PhpCfdi\Finkok\Services\Registration\CustomerType;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class AddCommandTest extends TestCase
+final class AddCommandTest extends TestCase
 {
     public function testAddCommandCreation(): void
     {

--- a/tests/Unit/Services/Registration/AddResultTest.php
+++ b/tests/Unit/Services/Registration/AddResultTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Finkok\Services\Registration\AddResult;
 
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class AddResultTest extends TestCase
+final class AddResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponses(): void
     {

--- a/tests/Unit/Services/Registration/AddServiceTest.php
+++ b/tests/Unit/Services/Registration/AddServiceTest.php
@@ -10,7 +10,7 @@ use PhpCfdi\Finkok\Services\Registration\CustomerType;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class AddServiceTest extends TestCase
+final class AddServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {

--- a/tests/Unit/Services/Registration/AssignCommandTest.php
+++ b/tests/Unit/Services/Registration/AssignCommandTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Registration;
 use PhpCfdi\Finkok\Services\Registration\AssignCommand;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class AssignCommandTest extends TestCase
+final class AssignCommandTest extends TestCase
 {
     public function testAssignCommandCreation(): void
     {

--- a/tests/Unit/Services/Registration/AssignResultTest.php
+++ b/tests/Unit/Services/Registration/AssignResultTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Finkok\Services\Registration\AssignResult;
 
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class AssignResultTest extends TestCase
+final class AssignResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponses(): void
     {

--- a/tests/Unit/Services/Registration/AssignServiceTest.php
+++ b/tests/Unit/Services/Registration/AssignServiceTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Services\Registration\AssignService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class AssignServiceTest extends TestCase
+final class AssignServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {

--- a/tests/Unit/Services/Registration/CustomerTest.php
+++ b/tests/Unit/Services/Registration/CustomerTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Registration;
 use PhpCfdi\Finkok\Services\Registration\Customer;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class CustomerTest extends TestCase
+final class CustomerTest extends TestCase
 {
     public function testCreateEmpty(): void
     {

--- a/tests/Unit/Services/Registration/CustomersTest.php
+++ b/tests/Unit/Services/Registration/CustomersTest.php
@@ -8,7 +8,7 @@ use LogicException;
 use PhpCfdi\Finkok\Services\Registration\Customers;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class CustomersTest extends TestCase
+final class CustomersTest extends TestCase
 {
     public function testCreateUsingNoItems(): void
     {

--- a/tests/Unit/Services/Registration/EditCommandTest.php
+++ b/tests/Unit/Services/Registration/EditCommandTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Finkok\Services\Registration\CustomerStatus;
 use PhpCfdi\Finkok\Services\Registration\EditCommand;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class EditCommandTest extends TestCase
+final class EditCommandTest extends TestCase
 {
     public function testEditCommandCreation(): void
     {

--- a/tests/Unit/Services/Registration/EditResultTest.php
+++ b/tests/Unit/Services/Registration/EditResultTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Finkok\Services\Registration\EditResult;
 
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class EditResultTest extends TestCase
+final class EditResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponses(): void
     {

--- a/tests/Unit/Services/Registration/EditServiceTest.php
+++ b/tests/Unit/Services/Registration/EditServiceTest.php
@@ -10,7 +10,7 @@ use PhpCfdi\Finkok\Services\Registration\EditService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class EditServiceTest extends TestCase
+final class EditServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {

--- a/tests/Unit/Services/Registration/ObtainCommandTest.php
+++ b/tests/Unit/Services/Registration/ObtainCommandTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Registration;
 use PhpCfdi\Finkok\Services\Registration\ObtainCommand;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class ObtainCommandTest extends TestCase
+final class ObtainCommandTest extends TestCase
 {
     public function testObtainCommandCreation(): void
     {

--- a/tests/Unit/Services/Registration/ObtainResultTest.php
+++ b/tests/Unit/Services/Registration/ObtainResultTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Finkok\Services\Registration\ObtainResult;
 
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class ObtainResultTest extends TestCase
+final class ObtainResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponses(): void
     {

--- a/tests/Unit/Services/Registration/ObtainServiceTest.php
+++ b/tests/Unit/Services/Registration/ObtainServiceTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Services\Registration\ObtainService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class ObtainServiceTest extends TestCase
+final class ObtainServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResultWithRfc(): void
     {

--- a/tests/Unit/Services/Registration/SwitchCommandTest.php
+++ b/tests/Unit/Services/Registration/SwitchCommandTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Finkok\Services\Registration\CustomerType;
 use PhpCfdi\Finkok\Services\Registration\SwitchCommand;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class SwitchCommandTest extends TestCase
+final class SwitchCommandTest extends TestCase
 {
     public function testSwitchCommandCreation(): void
     {

--- a/tests/Unit/Services/Registration/SwitchResultTest.php
+++ b/tests/Unit/Services/Registration/SwitchResultTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Finkok\Services\Registration\SwitchResult;
 
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class SwitchResultTest extends TestCase
+final class SwitchResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponses(): void
     {

--- a/tests/Unit/Services/Registration/SwitchServiceTest.php
+++ b/tests/Unit/Services/Registration/SwitchServiceTest.php
@@ -10,7 +10,7 @@ use PhpCfdi\Finkok\Services\Registration\SwitchService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class SwitchServiceTest extends TestCase
+final class SwitchServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {

--- a/tests/Unit/Services/Retentions/CancelSignatureCommandTest.php
+++ b/tests/Unit/Services/Retentions/CancelSignatureCommandTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Finkok\Definitions\CancelStorePending;
 use PhpCfdi\Finkok\Services\Retentions\CancelSignatureCommand;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class CancelSignatureCommandTest extends TestCase
+final class CancelSignatureCommandTest extends TestCase
 {
     public function testCommandDefaultValue(): void
     {

--- a/tests/Unit/Services/Retentions/CancelSignatureResultTest.php
+++ b/tests/Unit/Services/Retentions/CancelSignatureResultTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Retentions;
 use PhpCfdi\Finkok\Services\Retentions\CancelSignatureResult;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class CancelSignatureResultTest extends TestCase
+final class CancelSignatureResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponses(): void
     {

--- a/tests/Unit/Services/Retentions/CancelSignatureServiceTest.php
+++ b/tests/Unit/Services/Retentions/CancelSignatureServiceTest.php
@@ -11,7 +11,7 @@ use PhpCfdi\Finkok\Services\Retentions\CancelSignatureService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class CancelSignatureServiceTest extends TestCase
+final class CancelSignatureServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {

--- a/tests/Unit/Services/Retentions/StampCommandTest.php
+++ b/tests/Unit/Services/Retentions/StampCommandTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Finkok\Services\Retentions\StampCommand;
 use PhpCfdi\Finkok\Tests\Factories\RandomPreCfdiRetention;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class StampCommandTest extends TestCase
+final class StampCommandTest extends TestCase
 {
     public function testSignStampCommandCanReceiveAPrecfdi(): void
     {

--- a/tests/Unit/Services/Retentions/StampResultTest.php
+++ b/tests/Unit/Services/Retentions/StampResultTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Retentions;
 use PhpCfdi\Finkok\Services\Retentions\StampResult;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class StampResultTest extends TestCase
+final class StampResultTest extends TestCase
 {
     public function testUsingKnownStampResponse(): void
     {

--- a/tests/Unit/Services/Retentions/StampServiceTest.php
+++ b/tests/Unit/Services/Retentions/StampServiceTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Services\Retentions\StampService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class StampServiceTest extends TestCase
+final class StampServiceTest extends TestCase
 {
     public function testSignStampSendXmlAndProcessPreparedResult(): void
     {

--- a/tests/Unit/Services/Retentions/StampedCommandTest.php
+++ b/tests/Unit/Services/Retentions/StampedCommandTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Finkok\Services\Retentions\StampedCommand;
 use PhpCfdi\Finkok\Tests\Factories\RandomPreCfdiRetention;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class StampedCommandTest extends TestCase
+final class StampedCommandTest extends TestCase
 {
     public function testSignStampedCommandCanReceiveAPrecfdi(): void
     {

--- a/tests/Unit/Services/Retentions/StampedResultTest.php
+++ b/tests/Unit/Services/Retentions/StampedResultTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Retentions;
 use PhpCfdi\Finkok\Services\Retentions\StampedResult;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class StampedResultTest extends TestCase
+final class StampedResultTest extends TestCase
 {
     public function testUsingKnownStampResponse(): void
     {

--- a/tests/Unit/Services/Retentions/StampedServiceTest.php
+++ b/tests/Unit/Services/Retentions/StampedServiceTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Services\Retentions\StampedService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class StampedServiceTest extends TestCase
+final class StampedServiceTest extends TestCase
 {
     public function testSignStampSendXmlAndProcessPreparedResult(): void
     {

--- a/tests/Unit/Services/Stamping/QueryPendingCommandTest.php
+++ b/tests/Unit/Services/Stamping/QueryPendingCommandTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Stamping;
 use PhpCfdi\Finkok\Services\Stamping\QueryPendingCommand;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class QueryPendingCommandTest extends TestCase
+final class QueryPendingCommandTest extends TestCase
 {
     public function testCreateCommand(): void
     {

--- a/tests/Unit/Services/Stamping/QueryPendingResultTest.php
+++ b/tests/Unit/Services/Stamping/QueryPendingResultTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Stamping;
 use PhpCfdi\Finkok\Services\Stamping\QueryPendingResult;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class QueryPendingResultTest extends TestCase
+final class QueryPendingResultTest extends TestCase
 {
     public function testUsingKnownStampResponse(): void
     {

--- a/tests/Unit/Services/Stamping/QueryPendingServiceTest.php
+++ b/tests/Unit/Services/Stamping/QueryPendingServiceTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Services\Stamping\QueryPendingService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class QueryPendingServiceTest extends TestCase
+final class QueryPendingServiceTest extends TestCase
 {
     public function testCall(): void
     {

--- a/tests/Unit/Services/Stamping/QuickStampServiceTest.php
+++ b/tests/Unit/Services/Stamping/QuickStampServiceTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Services\Stamping\StampingCommand;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class QuickStampServiceTest extends TestCase
+final class QuickStampServiceTest extends TestCase
 {
     public function testQuickStampSendXmlAndProcessPreparedResult(): void
     {

--- a/tests/Unit/Services/Stamping/StampServiceTest.php
+++ b/tests/Unit/Services/Stamping/StampServiceTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Services\Stamping\StampService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class StampServiceTest extends TestCase
+final class StampServiceTest extends TestCase
 {
     public function testStampSendXmlAndProcessPreparedResult(): void
     {

--- a/tests/Unit/Services/Stamping/StampedServiceTest.php
+++ b/tests/Unit/Services/Stamping/StampedServiceTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Services\Stamping\StampingCommand;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class StampedServiceTest extends TestCase
+final class StampedServiceTest extends TestCase
 {
     public function testStampedSendXmlAndProcessPreparedResult(): void
     {

--- a/tests/Unit/Services/Stamping/StampingAlertTest.php
+++ b/tests/Unit/Services/Stamping/StampingAlertTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Stamping;
 use PhpCfdi\Finkok\Services\Stamping\StampingAlert;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class StampingAlertTest extends TestCase
+final class StampingAlertTest extends TestCase
 {
     public function testCreateEmpty(): void
     {

--- a/tests/Unit/Services/Stamping/StampingAlertsTest.php
+++ b/tests/Unit/Services/Stamping/StampingAlertsTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Stamping;
 use PhpCfdi\Finkok\Services\Stamping\StampingAlerts;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class StampingAlertsTest extends TestCase
+final class StampingAlertsTest extends TestCase
 {
     public function testCreateEmpty(): void
     {

--- a/tests/Unit/Services/Stamping/StampingCommandTest.php
+++ b/tests/Unit/Services/Stamping/StampingCommandTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Finkok\Services\Stamping\StampingCommand;
 use PhpCfdi\Finkok\Tests\Factories\RandomPreCfdi;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class StampingCommandTest extends TestCase
+final class StampingCommandTest extends TestCase
 {
     public function testStampingCommandCanReceiveAPrecfdi(): void
     {

--- a/tests/Unit/Services/Stamping/StampingResultTest.php
+++ b/tests/Unit/Services/Stamping/StampingResultTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Stamping;
 use PhpCfdi\Finkok\Services\Stamping\StampingResult;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class StampingResultTest extends TestCase
+final class StampingResultTest extends TestCase
 {
     public function testUsingKnownStampResponse(): void
     {

--- a/tests/Unit/Services/TestingResult.php
+++ b/tests/Unit/Services/TestingResult.php
@@ -6,7 +6,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services;
 
 use PhpCfdi\Finkok\Services\AbstractResult;
 
-class TestingResult extends AbstractResult
+final class TestingResult extends AbstractResult
 {
     /**
      * @param string ...$search

--- a/tests/Unit/Services/Utilities/DatetimeCommandTest.php
+++ b/tests/Unit/Services/Utilities/DatetimeCommandTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Utilities;
 use PhpCfdi\Finkok\Services\Utilities\DatetimeCommand;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class DatetimeCommandTest extends TestCase
+final class DatetimeCommandTest extends TestCase
 {
     public function testDatetimeCommandWithValidPostalCode(): void
     {

--- a/tests/Unit/Services/Utilities/DatetimeServiceTest.php
+++ b/tests/Unit/Services/Utilities/DatetimeServiceTest.php
@@ -11,7 +11,7 @@ use PhpCfdi\Finkok\Tests\TestCase;
 
 final class DatetimeServiceTest extends TestCase
 {
-    public function testDatetimeServiceUsingPreparedResultWithoutPostalCode(): void
+    public function testDatetimeServiceUsingPreparedResultWithEmptyPostalCode(): void
     {
         $preparedResult = json_decode(TestCase::fileContentPath('utilities-datetime-response.json'));
 
@@ -21,7 +21,7 @@ final class DatetimeServiceTest extends TestCase
         $settings = $this->createSettingsFromEnvironment($soapFactory);
         $service = new DatetimeService($settings);
 
-        $result = $service->datetime();
+        $result = $service->datetime(new DatetimeCommand(''));
         $this->assertSame('2019-01-13T14:15:16', $result->datetime());
 
         $caller = $soapFactory->latestSoapCaller;

--- a/tests/Unit/Services/Utilities/DatetimeServiceTest.php
+++ b/tests/Unit/Services/Utilities/DatetimeServiceTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Services\Utilities\DatetimeService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class DatetimeServiceTest extends TestCase
+final class DatetimeServiceTest extends TestCase
 {
     public function testDatetimeServiceUsingPreparedResultWithoutPostalCode(): void
     {

--- a/tests/Unit/Services/Utilities/DownloadXmlCommandTest.php
+++ b/tests/Unit/Services/Utilities/DownloadXmlCommandTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Utilities;
 use PhpCfdi\Finkok\Services\Utilities\DownloadXmlCommand;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class DownloadXmlCommandTest extends TestCase
+final class DownloadXmlCommandTest extends TestCase
 {
     public function testDownloadXmlCommandCanReceiveAPrecfdi(): void
     {

--- a/tests/Unit/Services/Utilities/DownloadXmlResultTest.php
+++ b/tests/Unit/Services/Utilities/DownloadXmlResultTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\Finkok\Services\Utilities\DownloadXmlResult;
 
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class DownloadXmlResultTest extends TestCase
+final class DownloadXmlResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponses(): void
     {

--- a/tests/Unit/Services/Utilities/DownloadXmlServiceTest.php
+++ b/tests/Unit/Services/Utilities/DownloadXmlServiceTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Services\Utilities\DownloadXmlService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class DownloadXmlServiceTest extends TestCase
+final class DownloadXmlServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {

--- a/tests/Unit/Services/Utilities/ReportCreditCommandTest.php
+++ b/tests/Unit/Services/Utilities/ReportCreditCommandTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Utilities;
 use PhpCfdi\Finkok\Services\Utilities\ReportCreditCommand;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class ReportCreditCommandTest extends TestCase
+final class ReportCreditCommandTest extends TestCase
 {
     public function testReportCreditCommandCreation(): void
     {

--- a/tests/Unit/Services/Utilities/ReportCreditResultTest.php
+++ b/tests/Unit/Services/Utilities/ReportCreditResultTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Utilities;
 use PhpCfdi\Finkok\Services\Utilities\ReportCreditResult;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class ReportCreditResultTest extends TestCase
+final class ReportCreditResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponse(): void
     {

--- a/tests/Unit/Services/Utilities/ReportCreditServiceTest.php
+++ b/tests/Unit/Services/Utilities/ReportCreditServiceTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Services\Utilities\ReportCreditService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class ReportCreditServiceTest extends TestCase
+final class ReportCreditServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {

--- a/tests/Unit/Services/Utilities/ReportTotalCommandTest.php
+++ b/tests/Unit/Services/Utilities/ReportTotalCommandTest.php
@@ -10,7 +10,7 @@ use LogicException;
 use PhpCfdi\Finkok\Services\Utilities\ReportTotalCommand;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class ReportTotalCommandTest extends TestCase
+final class ReportTotalCommandTest extends TestCase
 {
     public function testReportTotalCommandPastPeriods(): void
     {
@@ -159,6 +159,7 @@ class ReportTotalCommandTest extends TestCase
                 parent::__construct($rfc, $type, $startYear, $startMonth, $endYear, $endMonth);
             }
 
+            /** @noinspection PhpMissingParentCallCommonInspection */
             protected function today(): DateTimeImmutable
             {
                 return $this->today;

--- a/tests/Unit/Services/Utilities/ReportTotalResultTest.php
+++ b/tests/Unit/Services/Utilities/ReportTotalResultTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Utilities;
 use PhpCfdi\Finkok\Services\Utilities\ReportTotalResult;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class ReportTotalResultTest extends TestCase
+final class ReportTotalResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponse(): void
     {

--- a/tests/Unit/Services/Utilities/ReportTotalServiceTest.php
+++ b/tests/Unit/Services/Utilities/ReportTotalServiceTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\Finkok\Services\Utilities\ReportTotalService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class ReportTotalServiceTest extends TestCase
+final class ReportTotalServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {

--- a/tests/Unit/Services/Utilities/ReportUuidCommandTest.php
+++ b/tests/Unit/Services/Utilities/ReportUuidCommandTest.php
@@ -9,7 +9,7 @@ use LogicException;
 use PhpCfdi\Finkok\Services\Utilities\ReportUuidCommand;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class ReportUuidCommandTest extends TestCase
+final class ReportUuidCommandTest extends TestCase
 {
     public function testReportUuidCommandCreation(): void
     {

--- a/tests/Unit/Services/Utilities/ReportUuidResultTest.php
+++ b/tests/Unit/Services/Utilities/ReportUuidResultTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Utilities;
 use PhpCfdi\Finkok\Services\Utilities\ReportUuidResult;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class ReportUuidResultTest extends TestCase
+final class ReportUuidResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponse(): void
     {

--- a/tests/Unit/Services/Utilities/ReportUuidServiceTest.php
+++ b/tests/Unit/Services/Utilities/ReportUuidServiceTest.php
@@ -10,7 +10,7 @@ use PhpCfdi\Finkok\Services\Utilities\ReportUuidService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
 
-class ReportUuidServiceTest extends TestCase
+final class ReportUuidServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {


### PR DESCRIPTION
- Se elimina el soporte y dependencia de PHP 7.2.
- Se agrega el soporte de PHP 7.3.
- Se actualiza PHPUnit de 8.5 a 9.5.
- `PhpCfdi\Finkok\Services\Utilities\DatetimeService::datetime(DatetimeCommand $command = null)`
  no debe usar la opción de nulo, fue puesta para compatibilidad con versiones previas a `0.2.2`,
  no es así en las fachadas `Finkok` y `QuickFinkok`.
- Limpieza de código:
  - Remover variables locales innecesarias.
  - Remover código innecesario (inicializaciones a null, variables privadas sin uso).
  - Múltiples anotaciones para evitar alertas de PHPStorm.

Cambios en entorno de desarrollo:

- Se corrigen las pruebas de integración porque el sistema de pruebas del SAT reporta errores de sincronización.
- En desarrollo se depende ahora de `eclipxe/cfdiutils` compatible con PHP 8.0.
- Se corrigieron los scripts de `composer.json`.
- Los casos de pruebas son clases finales.
- Corrección de Travis-CI, estaba usando `phpcbf` en lugar de `phpcs`.
- Se agrega PHP 8.0 a la matriz de pruebas de Travis-CI.
- Se elimina la actualización de composer en Scrutinizer, el sistema es de solo lectura.
