### PR TITLE
Propuesta versión 0.3.2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 *.cer binary
 *.key binary
 *.bin binary
+*.enc binary
 
 # Do not put this files on a distribution package (by .gitignore)
 .env                        export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,19 +5,19 @@
 *.bin binary
 
 # Do not put this files on a distribution package (by .gitignore)
-.env                 export-ignore
-/vendor              export-ignore
-/composer.lock       export-ignore
+.env                        export-ignore
+/vendor                     export-ignore
+/composer.lock              export-ignore
 
 # Do not put this files on a distribution package
-/.github/            export-ignore
-/build/              export-ignore
-/docs/               export-ignore
-/tests/              export-ignore
-/.gitattributes      export-ignore
-/.gitignore          export-ignore
-/.php_cs.dist        export-ignore
-/.scrutinizer.yml    export-ignore
-/phpcs.xml.dist      export-ignore
-/phpstan.neon.dist   export-ignore
-/phpunit.xml.dist    export-ignore
+/.github/                   export-ignore
+/build/                     export-ignore
+/docs/                      export-ignore
+/tests/                     export-ignore
+/.gitattributes             export-ignore
+/.gitignore                 export-ignore
+/.php-cs-fixer.dist.php     export-ignore
+/.scrutinizer.yml           export-ignore
+/phpcs.xml.dist             export-ignore
+/phpstan.neon.dist          export-ignore
+/phpunit.xml.dist           export-ignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,15 +15,15 @@ jobs:
         php-versions: ['7.3', '7.4', '8.0']
 
     steps:
-      # see https://github.com/marketplace/actions/setup-php-action
       - name: Checkout
         uses: actions/checkout@v2
 
+      # see https://github.com/marketplace/actions/setup-php-action
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, json
+          extensions: json, soap, dom, openssl
           coverage: none
           tools: composer:v2, cs2pr
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Code style (php-cs-fixer)
         run: vendor/bin/php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
 
-      - name: Tests (phpunit)
+      - name: Unit tests (phpunit)
         run: vendor/bin/phpunit tests/Unit/ --testdox --verbose
 
       - name: Code analysis (phpstan)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,11 @@
 name: build
 on:
   pull_request:
+    branches:
+      - master
   push:
+    branches:
+      - master
   schedule:
     - cron: '0 16 * * 0' # sunday 16:00
 

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -1,0 +1,62 @@
+name: functional-tests
+on:
+  # secrets are not passed to workflows that are triggered by a pull request from a fork.
+  # see https://docs.github.com/en/actions/reference/encrypted-secrets
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Run tests with coverage
+    runs-on: "ubuntu-latest"
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # see https://github.com/marketplace/actions/setup-php-action
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.0"
+          extensions: json, soap, dom, openssl
+          coverage: xdebug
+          tools: composer:v2
+        env:
+          fail-fast: true
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Remove unused development dependencies
+        run: composer remove squizlabs/php_codesniffer friendsofphp/php-cs-fixer phpstan/phpstan --dev --no-interaction --no-progress --no-update
+
+      - name: Install project dependencies
+        run: composer upgrade --no-interaction --no-progress --prefer-dist
+
+      - name: Set up environment file
+        run: gpg --quiet --batch --yes --decrypt --passphrase="$ENV_GPG_SECRET" --output tests/.env tests/.env-testing.enc
+        env:
+          ENV_GPG_SECRET: ${{ secrets.ENV_GPG_SECRET }}
+
+      - name: Run integration tests with code coverage
+        run: vendor/bin/phpunit --testdox --verbose --exclude-group large --coverage-clover=build/coverage-clover.xml
+
+      # see https://github.com/marketplace/actions/action-scrutinizer
+      - name: Upload code coverage to scrutinizer
+        uses: sudo-bot/action-scrutinizer@latest
+        with:
+          cli-args: "--format=php-clover build/coverage-clover.xml"

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-return PhpCsFixer\Config::create()
+return ( new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setCacheFile(__DIR__ . '/build/.php_cs.cache')
     ->setRules([
@@ -18,7 +18,7 @@ return PhpCsFixer\Config::create()
         'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
         'no_alias_functions' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
         'new_with_braces' => true,
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -7,14 +7,12 @@ filter:
 build:
   dependencies:
     override:
-      - composer remove squizlabs/php_codesniffer friendsofphp/php-cs-fixer phpstan/phpstan --dev --no-interaction --no-progress --no-update
-      - composer update --no-interaction
+      - composer update --no-interaction --no-dev
   nodes:
     php:
       tests:
         override:
           - php-scrutinizer-run --enable-security-analysis
-          - command: vendor/bin/phpunit tests/Unit/ --testdox --verbose --coverage-clover=coverage.clover
-            coverage:
-              file: coverage.clover
-              format: clover
+
+tools:
+  external_code_coverage: true

--- a/composer.json
+++ b/composer.json
@@ -41,8 +41,8 @@
         "symfony/dotenv": "^5.1",
         "eclipxe/cfdiutils": "^2.15",
         "phpunit/phpunit": "^9.5",
-        "squizlabs/php_codesniffer": "^3.0",
-        "friendsofphp/php-cs-fixer": "^2.4",
+        "squizlabs/php_codesniffer": "^3.6",
+        "friendsofphp/php-cs-fixer": "^3.0",
         "phpstan/phpstan": "^0.12.54"
     },
     "autoload": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor el control de versiones.
 
+## Pendientes para siguiente versión mayor
+
+- Eliminar `CancelledDocument::cancellationSatatus()`.
+
+## Version 0.3.2 2021-03-23
+
+Se renombra la propiedad `CancelledDocument::cancellationSatatus()` en favor de `CancelledDocument::cancellationStatus()`
+que no tiene el error de ortografía. Será removida en la versión 0.4.0.
+
 ## Version 0.3.1 2021-03-21
 
 En la versión 0.3.0 se mencionó que la fachada `Finkok::datetime()` podía seguir existiendo, pero es incorrecto.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,10 +6,18 @@ Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor e
 
 - Eliminar `CancelledDocument::cancellationSatatus()`.
 
-## Version 0.3.2 2021-03-23
+## Version 0.3.2 2021-05-21
 
 Se renombra la propiedad `CancelledDocument::cancellationSatatus()` en favor de `CancelledDocument::cancellationStatus()`
 que no tiene el error de ortografía. Será removida en la versión 0.4.0.
+
+Los siguientes son cambios en desarrollo y no tienen afectación en el código productivo:
+
+- Se actualiza `php-cs-fixer: ^3.0`.
+- Se corrigen las extensiones en la configuración de `shivammathur/setup-php` en la acción de construcción.
+- Se agrega la construcción de la rama principal en la acción de construcción.
+- Se actualiza la configuración de PHPUnit.
+- Se cambia la generación de la cobertura de código a la acción de pruebas funciones y se sube a Scrutinizer.
 
 ## Version 0.3.1 2021-03-21
 

--- a/docs/Ejemplos/CancelacionFirmada.md
+++ b/docs/Ejemplos/CancelacionFirmada.md
@@ -25,7 +25,7 @@ $documentInfo = $result->documents()->first();
 echo 'Código de estado de la solicitud de cancelación: ', $result->statusCode();
 echo 'UUID: ', $documentInfo->uuid();
 echo 'Estado del CFDI: ', $documentInfo->documentStatus();
-echo 'Estado de cancelación: ', $documentInfo->cancellationSatatus();
+echo 'Estado de cancelación: ', $documentInfo->cancellationStatus();
 ```
 
 ## Ejemplo usando phpcfdi/xml-cancelacion (versión 0.2.0)

--- a/docs/PruebasDeIntegracionContinua.md
+++ b/docs/PruebasDeIntegracionContinua.md
@@ -1,0 +1,54 @@
+# Pruebas de integración contínua
+
+Se ha configurado este proyecto para correr las pruebas de integración contínua utilizando la plataforma
+de GitHub Actions.
+
+Hay dos trabajos de ejecución que ejecutan al hacer un push o un pull request sobre la rama principal:
+
+- Prueba general de contrucción `build.yml`.
+- Pruebas funcionales `functional-test.yml`.
+
+## Pruebas generales
+
+Las pruebas generales que se ejecutan tienen que ver con el estilo de código, pruebas unitarias (no funcionales),
+y anásis estático de código. Estas pruebas son las que están vinculadas con el estado de la contrucción
+en el *badge* *build*.
+
+Adicionalmente, se ejecutan estas pruebas todos los domingos a las 16:00 horas.
+
+## Pruebas funcionales
+
+Las pruebas funcionales consisten en la ejecución de todas las pruebas con la excepción de aquellas que estén
+marcadas con la etiqueta `@group large`.
+
+Este tipo de pruebas hace contacto con la plataforma de pruebas de Finkok, por lo que es necesario contar
+con una cuenta y configurar correctamente el archivo de configuración de entorno `.env`.
+Lee el archivo de [Pruebas de Integracion](PruebasDeIntegracion.md) para más información.
+
+### Protección de los datos de configuración de entorno
+
+Las pruebas funcionales dependen del archivo de configuración de entorno `tests/.env`, el cual contiene
+información sensible como la credencial de Finkok. Para protegerlo se utiliza el almacenamiento de secretos
+de GitHub <https://docs.github.com/es/actions/reference/encrypted-secrets> y GPG para encriptar y desencriptar
+el archivo de configuración de entorno.
+
+El secreto en cuestión está almacenado en `secrets.ENV_GPG_SECRET` a nivel repositorio.
+
+Para encriptar el archivo de configuración `tests/.env -> tests/.env-testing.enc`, al ejecutar el comando
+se solicitará la frase de contraseña, que es lo que se debe almacenar en el secreto.
+
+```shell
+gpg --no-symkey-cache --symmetric --cipher-algo AES256 --output tests/.env-testing.enc tests/.env
+```
+
+Para desencriptar el archivo de configuración `tests/.env-testing.enc -> tests/.env` se puede usar el siguiente
+comando. Esta operación es la que se ejecuta en `functional-test.yml` usando el secreto `secrets.ENV_GPG_SECRET`.
+
+```shell
+gpg --quiet --batch --yes --decrypt --output decoded tests/.env-testing.enc
+```
+
+### Cobertura de código
+
+Las pruebas de funcionales son las que establecen la mayor cobertura de código, entonces, en su ejecución
+se genera el archivo de cobertura y se publica en Scrutinizer.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,23 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-        bootstrap="./tests/bootstrap.php" colors="true" cacheResult="false">
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="tests/bootstrap.php"
+    cacheResultFile="build/phpunit.cache/test-results"
+    executionOrder="depends,defects"
+    failOnRisky="true"
+    failOnWarning="true"
+    verbose="true"
+    colors="true">
+
     <testsuites>
-        <testsuite name="Default">
-            <directory>./tests/</directory>
+        <testsuite name="default">
+            <directory suffix="Test.php">./tests/</directory>
         </testsuite>
     </testsuites>
-  <coverage>
-      <include>
-          <directory suffix=".php">./src/</directory>
-      </include>
-  </coverage>
+
+    <coverage cacheDirectory="build/phpunit.cache/code-coverage" processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src/</directory>
+        </include>
+    </coverage>
 </phpunit>

--- a/src/Services/Cancel/CancelledDocument.php
+++ b/src/Services/Cancel/CancelledDocument.php
@@ -31,6 +31,20 @@ class CancelledDocument
         return $this->get('EstatusUUID');
     }
 
+    /**
+     * @return string
+     * @deprecated 0.3.2
+     * @see self::cancellationStatus
+     */
+    public function cancellationSatatus(): string
+    {
+        trigger_error(
+            sprintf('%s is deprecated since 0.3.2 and will be removed on 0.4.0', __METHOD__),
+            E_USER_DEPRECATED
+        );
+        return $this->cancellationStatus();
+    }
+
     public function cancellationStatus(): string
     {
         return $this->get('EstatusCancelacion');

--- a/src/Services/Cancel/CancelledDocument.php
+++ b/src/Services/Cancel/CancelledDocument.php
@@ -31,7 +31,7 @@ class CancelledDocument
         return $this->get('EstatusUUID');
     }
 
-    public function cancellationSatatus(): string
+    public function cancellationStatus(): string
     {
         return $this->get('EstatusCancelacion');
     }

--- a/tests/.env-testing.enc
+++ b/tests/.env-testing.enc
@@ -1,0 +1,1 @@
+Œ	òÓ™AxxÿÒÀÞ(ea‘/ÿžü¨¬åOÊ›y\—$þðE5Ó{’©q’Ñ[êK&2£L_RÚ´pZù`Ô‚ý;ÇPòõz„£µ‚PnÉ\É,Ü’bs€’®´s¨JWžb“`yG¨&1ên.ø‰ŠQC¸FÖŽÈIc]£6¬þ–s†BÍ>óNŒ´ÞüÉ¯U‚çÖ˜Z[H¸>IG––:›:_›…Îð|ÅâØhnU±»ÑØ!ù•Ÿúßf¡OíjäcN/Gèä$Ë>••›«?O?¨»”ð­/ËÞ³`RuZç2YñQÖ@&PáªK3pÎ¬;ò4ò¾Ýu¥üüJb°ÿêsæ:oZù@þ:˜*ã<éŠ½òÞI·úa‚7|*g¦«3:wÛi‘æÊÅ‚òtV')Î°³‰	µïÊ„{Y,‚Æ;>²ÆVÜô	gp;žsÛãÀµ?öË+AóT©Ë«r]-¡˜,«eaöÈ-ÉŸþv¨>EŸ½5t­¤sÖêiŠ0ª¾‡[±B°±5:‹¨m

--- a/tests/Integration/Services/Cancel/CancelServicesTest.php
+++ b/tests/Integration/Services/Cancel/CancelServicesTest.php
@@ -12,6 +12,7 @@ use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
 final class CancelServicesTest extends IntegrationTestCase
 {
+    /** @group large */
     public function testCreateCfdiThenGetSatStatusThenCancelSignatureThenGetReceipt(): void
     {
         $settings = $this->createSettingsFromEnvironment();

--- a/tests/Integration/Services/Cancel/GetRelatedSignatureServiceTest.php
+++ b/tests/Integration/Services/Cancel/GetRelatedSignatureServiceTest.php
@@ -45,6 +45,7 @@ final class GetRelatedSignatureServiceTest extends IntegrationTestCase
         return new StampingCommand($precfdi);
     }
 
+    /** @group large */
     public function testConsumeServiceWithRelated(): void
     {
         // first is child of second, second is parent of first
@@ -79,7 +80,7 @@ final class GetRelatedSignatureServiceTest extends IntegrationTestCase
 
             // try  again
             if (time() > $maxtime) {
-                $this->fail("After 5 minutes consuming GetRelatedSignatureService didn't get related from SAT");
+                $this->fail("After 10 minutes consuming GetRelatedSignatureService didn't get related from SAT");
             }
             sleep(5);
         }

--- a/tests/Integration/Services/Registration/AddServiceTest.php
+++ b/tests/Integration/Services/Registration/AddServiceTest.php
@@ -40,6 +40,7 @@ final class AddServiceTest extends RegistrationIntegrationTestCase
         $this->assertSame('Account Already exists', $result->message());
     }
 
+    /** @group large */
     public function testConsumeAddServiceWithRandomRfc(): void
     {
         // Finkok does not have a method (automated or manual) to remove customers.

--- a/tests/Integration/Services/Retentions/CancelSignatureServiceTest.php
+++ b/tests/Integration/Services/Retentions/CancelSignatureServiceTest.php
@@ -28,6 +28,7 @@ final class CancelSignatureServiceTest extends RetentionsTestCase
         $this->assertSame('UUID Not Found', $result->statusCode());
     }
 
+    /** @group large */
     public function testCancelSignatureRecentlyCreatedDocument(): void
     {
         $stampedToCancel = $this->quickFinkok->retentionStamp($this->newRetentionsPreCfdi());

--- a/tests/Unit/Services/Cancel/CancelledDocumentTest.php
+++ b/tests/Unit/Services/Cancel/CancelledDocumentTest.php
@@ -6,7 +6,6 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Cancel;
 
 use PhpCfdi\Finkok\Services\Cancel\CancelledDocument;
 use PhpCfdi\Finkok\Tests\TestCase;
-use PHPUnit\Framework\Error\Deprecated;
 
 final class CancelledDocumentTest extends TestCase
 {

--- a/tests/Unit/Services/Cancel/CancelledDocumentTest.php
+++ b/tests/Unit/Services/Cancel/CancelledDocumentTest.php
@@ -6,6 +6,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Cancel;
 
 use PhpCfdi\Finkok\Services\Cancel\CancelledDocument;
 use PhpCfdi\Finkok\Tests\TestCase;
+use PHPUnit\Framework\Error\Deprecated;
 
 final class CancelledDocumentTest extends TestCase
 {
@@ -27,5 +28,30 @@ final class CancelledDocumentTest extends TestCase
         $this->assertSame('708', $folio->documentStatus());
         $this->assertSame('foo bar', $folio->cancellationStatus());
         $this->assertSame($data, $folio->values());
+    }
+
+    public function testMethodCancellationSatatusIsDeprecated(): void
+    {
+        $data = [
+            'UUID' => '728147B1-D5B9-4FDD-AEA9-526AEA2E6698',
+            'EstatusUUID' => '708',
+            'EstatusCancelacion' => 'foo bar',
+        ];
+        $document = new CancelledDocument((object) $data);
+        $this->expectDeprecation();
+        $document->cancellationSatatus();
+    }
+
+    public function testMethodCancellationSatatusReturnExpectedValue(): void
+    {
+        $data = [
+            'UUID' => '728147B1-D5B9-4FDD-AEA9-526AEA2E6698',
+            'EstatusUUID' => '708',
+            'EstatusCancelacion' => 'foo bar',
+        ];
+        $document = new CancelledDocument((object) $data);
+        /** @noinspection PhpUsageOfSilenceOperatorInspection */
+        $retrieved = @$document->cancellationSatatus();
+        $this->assertSame($document->cancellationStatus(), $retrieved);
     }
 }

--- a/tests/Unit/Services/Cancel/CancelledDocumentTest.php
+++ b/tests/Unit/Services/Cancel/CancelledDocumentTest.php
@@ -25,7 +25,7 @@ final class CancelledDocumentTest extends TestCase
         $folio = new CancelledDocument((object) $data);
         $this->assertSame('728147B1-D5B9-4FDD-AEA9-526AEA2E6698', $folio->uuid());
         $this->assertSame('708', $folio->documentStatus());
-        $this->assertSame('foo bar', $folio->cancellationSatatus());
+        $this->assertSame('foo bar', $folio->cancellationStatus());
         $this->assertSame($data, $folio->values());
     }
 }


### PR DESCRIPTION
Se renombra la propiedad `CancelledDocument::cancellationSatatus()` en favor de `CancelledDocument::cancellationStatus()`
que no tiene el error de ortografía. Será removida en la versión 0.4.0.

Los siguientes son cambios en desarrollo y no tienen afectación en el código productivo:

- Se actualiza `php-cs-fixer: ^3.0`.
- Se corrigen las extensiones en la configuración de `shivammathur/setup-php` en la acción de construcción.
- Se agrega la construcción de la rama principal en la acción de construcción.
- Se actualiza la configuración de PHPUnit.
- Se cambia la generación de la cobertura de código a la acción de pruebas funciones y se sube a Scrutinizer.