### PR TITLE
Fix broken CI 2021-09-26 and improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,7 +13,6 @@
 # Do not put this files on a distribution package
 /.github/                   export-ignore
 /build/                     export-ignore
-/docs/                      export-ignore
 /tests/                     export-ignore
 /.gitattributes             export-ignore
 /.gitignore                 export-ignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,9 @@
 name: build
 on:
   pull_request:
-    branches:
-      - master
+    branches: [ 'main' ]
   push:
-    branches:
-      - master
+    branches: [ 'main' ]
   schedule:
     - cron: '0 16 * * 0' # sunday 16:00
 

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -3,11 +3,9 @@ on:
   # secrets are not passed to workflows that are triggered by a pull request from a fork.
   # see https://docs.github.com/en/actions/reference/encrypted-secrets
   pull_request:
-    branches:
-      - master
+    branches: [ 'main' ]
   push:
-    branches:
-      - master
+    branches: [ 'main' ]
 
 jobs:
   build:

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -2,14 +2,12 @@ name: functional-tests
 on:
   # secrets are not passed to workflows that are triggered by a pull request from a fork.
   # see https://docs.github.com/en/actions/reference/encrypted-secrets
-  pull_request:
-    branches: [ 'main' ]
   push:
     branches: [ 'main' ]
 
 jobs:
-  build:
-    name: Run tests with coverage
+  functional-tests:
+    name: Functional tests
     runs-on: "ubuntu-latest"
 
     steps:
@@ -58,3 +56,4 @@ jobs:
         uses: sudo-bot/action-scrutinizer@latest
         with:
           cli-args: "--format=php-clover build/coverage-clover.xml"
+        continue-on-error: true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# Código de Conducta convenido para Contribuyentes
+# Código de Conducta Convenido para Contribuyentes
 
 ## Nuestro compromiso
 
@@ -39,7 +39,7 @@ Este código de conducta aplica tanto a espacios del proyecto como a espacios p�
 
 ## Aplicación
 
-Instancias de comportamiento abusivo, acosador o inaceptable de otro modo podrán ser reportadas a los administradores de la comunidad responsables del cumplimiento a través de [INSERTAR MÉTODO DE CONTACTO]. Todas las quejas serán evaluadas e investigadas de una manera puntual y justa.
+Instancias de comportamiento abusivo, acosador o inaceptable de otro modo podrán ser reportadas a los administradores de la comunidad responsables del cumplimiento a través de [coc@phpcfdi.com](). Todas las quejas serán evaluadas e investigadas de una manera puntual y justa.
 
 Todos los administradores de la comunidad están obligados a respetar la privacidad y la seguridad de quienes reporten incidentes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,8 @@ muestra en [`actions/setup-php-action`](https://github.com/marketplace/actions/s
 puedes ejecutar el siguiente comando:
 
 ```shell
-act -P ubuntu-latest=shivammathur/node:latest
+act -P ubuntu-latest=shivammathur/node:latest -j build
+act -P ubuntu-latest=shivammathur/node:latest -j functional-tests -s ENV_GPG_SECRET=**********
 ```
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,14 +49,14 @@ o la forma de desarrollarlas puede que no estén alineadas con el proyecto.
 
 Considera las siguientes directrices:
 
-* Usa una rama única que se desprenda de la rama principal.
+* Usa una rama única que se desprenda de la rama principal. 
   No mezcles dos diferentes funcionalidades en una misma rama o *Pull Request*.
 * Describe claramente y en detalle los cambios que hiciste.
 * **Escribe pruebas** para la funcionalidad que deseas agregar.
-* **Asegúrate que las pruebas pasan** antes de enviar tu contribución.
+* **Asegúrate que las pruebas pasan** antes de enviar tu contribución. 
   Usamos integración contínua donde se hace esta verificación, pero es mucho mejor si lo pruebas localmente.
 * Intenta enviar una historia coherente, entenderemos cómo cambia el código si los *commits* tienen significado.
-* La documentación es parte del proyecto.
+* La documentación es parte del proyecto. 
   Realiza los cambios en los archivos de ayuda para que reflejen los cambios en el código.
 
 ## Proceso de construcción

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,16 @@ Una vez correctamente configurado, ejecuta las pruebas de integración:
 vendor/bin/phpunit tests/Integration --testdox --verbose
 ```
 
+## Ejecutar GitHub Actions localmente
+
+Puedes usar [`act`](https://github.com/nektos/act) para ejecutar GitHub Actions localmente, tal como se
+muestra en [`actions/setup-php-action`](https://github.com/marketplace/actions/setup-php-action#local-testing-setup)
+puedes ejecutar el siguiente comando:
+
+```shell
+act -P ubuntu-latest=shivammathur/node:latest
+```
+
 
 [phpCfdi]:      https://github.com/phpcfdi/
 [project]:      https://github.com/phpcfdi/finkok

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,5 +93,5 @@ vendor/bin/phpunit tests/Integration --testdox --verbose
 [phpCfdi]:      https://github.com/phpcfdi/
 [project]:      https://github.com/phpcfdi/finkok
 [contributors]: https://github.com/phpcfdi/finkok/graphs/contributors
-[coc]:          https://github.com/phpcfdi/finkok/blob/master/CODE_OF_CONDUCT.md
+[coc]:          https://github.com/phpcfdi/finkok/blob/main/CODE_OF_CONDUCT.md
 [issues]:       https://github.com/phpcfdi/finkok/issues

--- a/README.md
+++ b/README.md
@@ -227,13 +227,13 @@ Durante el proceso de implementación he creado diversas notas y documentos:
 
 - Problemas encontrados:
     - [X] [Cancelación de un CFDI recién creado](docs/issues/CancelSignatureServiceCancelarRecienCreado.md)
-    - [X] [Consumir queryPending con un CFDI recién creado](docs/issues/QueryPendingServiceUuidNoExistente.md)
-    - [X] [Consumir stamp para generar un doble estampado no devuelve los datos](docs/issues/StampServiceDobleEstampado.md)
+    - [X] [Consumir `queryPending` con un CFDI recién creado](docs/issues/QueryPendingServiceUuidNoExistente.md)
+    - [X] [Consumir `stamp` para generar un doble estampado no devuelve los datos](docs/issues/StampServiceDobleEstampado.md)
     - [X] Falta servicio que no requiera CSD/FIEL para aceptar o rechazar una solicitud de cancelación
     - [X] Falta servicio que no requiera CSD/FIEL para obtener los CFDI relacionados
     - [X] [El acuse de cancelación entregado al cancelar y al solicitar el acuse no coinciden](docs/issues/AcuseCancelacionNoCoincidente.md)
     - [X] [Error de cancelación de retenciones 1308 - Certificado revocado o caduco](docs/issues/CancelacionRetencionesError1308.md)
-    - [X] [`CodEstatus` ausente en la cancelación de CFDI de Retenciones](docs/issues/CancelacionRetencionesCodEstatus.md)
+    - [X] [El valor `CodEstatus` está ausente en la cancelación de CFDI de Retenciones](docs/issues/CancelacionRetencionesCodEstatus.md)
 
 ## Compatibilidad
 

--- a/README.md
+++ b/README.md
@@ -233,9 +233,9 @@ Durante el proceso de implementación he creado diversas notas y documentos:
     - [X] Falta servicio que no requiera CSD/FIEL para obtener los CFDI relacionados
     - [X] [El acuse de cancelación entregado al cancelar y al solicitar el acuse no coinciden](docs/issues/AcuseCancelacionNoCoincidente.md)
     - [X] [Error de cancelación de retenciones 1308 - Certificado revocado o caduco](docs/issues/CancelacionRetencionesError1308.md)
-    - [ ] [`CodEstatus` ausente en la cancelación de CFDI de Retenciones](docs/issues/CancelacionRetencionesCodEstatus.md)
+    - [X] [`CodEstatus` ausente en la cancelación de CFDI de Retenciones](docs/issues/CancelacionRetencionesCodEstatus.md)
 
-## Compatilibilidad
+## Compatibilidad
 
 Esta librería se mantendrá compatible con al menos la versión con
 [soporte activo de PHP](https://www.php.net/supported-versions.php) más reciente.

--- a/README.md
+++ b/README.md
@@ -258,22 +258,22 @@ y recuerda revisar el archivo de tareas pendientes [TODO][] y el archivo [CHANGE
 The phpcfdi/finkok library is copyright © [PhpCfdi](https://www.phpcfdi.com)
 and licensed for use under the MIT License (MIT). Please see [LICENSE][] for more information.
 
-[contributing]: https://github.com/phpcfdi/finkok/blob/master/CONTRIBUTING.md
-[changelog]: https://github.com/phpcfdi/finkok/blob/master/docs/CHANGELOG.md
-[todo]: https://github.com/phpcfdi/finkok/blob/master/docs/TODO.md
+[contributing]: https://github.com/phpcfdi/finkok/blob/main/CONTRIBUTING.md
+[changelog]: https://github.com/phpcfdi/finkok/blob/main/docs/CHANGELOG.md
+[todo]: https://github.com/phpcfdi/finkok/blob/main/docs/TODO.md
 
 [source]: https://github.com/phpcfdi/finkok
 [release]: https://github.com/phpcfdi/finkok/releases
-[license]: https://github.com/phpcfdi/finkok/blob/master/LICENSE
-[build]: https://github.com/phpcfdi/finkok/actions/workflows/build.yml?query=branch:master
+[license]: https://github.com/phpcfdi/finkok/blob/main/LICENSE
+[build]: https://github.com/phpcfdi/finkok/actions/workflows/build.yml?query=branch:main
 [quality]: https://scrutinizer-ci.com/g/phpcfdi/finkok/
-[coverage]: https://scrutinizer-ci.com/g/phpcfdi/finkok/code-structure/master/code-coverage/src
+[coverage]: https://scrutinizer-ci.com/g/phpcfdi/finkok/code-structure/main/code-coverage/src
 [downloads]: https://packagist.org/packages/phpcfdi/finkok
 
 [badge-source]: https://img.shields.io/badge/source-phpcfdi/finkok-blue?style=flat-square
 [badge-release]: https://img.shields.io/github/release/phpcfdi/finkok?style=flat-square
 [badge-license]: https://img.shields.io/github/license/phpcfdi/finkok?style=flat-square
-[badge-build]: https://img.shields.io/github/workflow/status/phpcfdi/finkok/build/master?style=flat-square
-[badge-quality]: https://img.shields.io/scrutinizer/g/phpcfdi/finkok/master?style=flat-square
-[badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/phpcfdi/finkok/master?style=flat-square
+[badge-build]: https://img.shields.io/github/workflow/status/phpcfdi/finkok/build/main?style=flat-square
+[badge-quality]: https://img.shields.io/scrutinizer/g/phpcfdi/finkok/main?style=flat-square
+[badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/phpcfdi/finkok/main?style=flat-square
 [badge-downloads]: https://img.shields.io/packagist/dt/phpcfdi/finkok?style=flat-square

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         {
             "name": "Carlos C Soto",
             "email": "eclipxe13@gmail.com",
-            "homepage": "http://eclipxe.com.mx/"
+            "homepage": "https://eclipxe.com.mx/"
         }
     ],
     "support": {

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "ext-fileinfo": "*",
         "symfony/dotenv": "^5.1",
         "eclipxe/cfdiutils": "^2.15",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.5.10",
         "squizlabs/php_codesniffer": "^3.6",
         "friendsofphp/php-cs-fixer": "^3.0",
         "phpstan/phpstan": "^0.12.54"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,10 @@ Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor e
 
 - Eliminar `CancelledDocument::cancellationSatatus()`.
 
+## Unreleased
+
+- 2021-09-26: Fix broken CI. PHPUnit 9.5.10 does not convert deprecations to exceptions by default.
+
 ## Version 0.3.2 2021-05-21
 
 Se renombra la propiedad `CancelledDocument::cancellationSatatus()` en favor de `CancelledDocument::cancellationStatus()`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -78,7 +78,7 @@ Cambios en el entorno de pruebas (2020-09-18). Solo se afecta la rama principal,
 
 - En las pruebas de integración del servicio `get_related_signature` el SAT tarda en vincular los CFDI recientemente
   creados, lo que ocasiona que la prueba falle invariablemente al detectar el error
-  `2001 - No Existen cfdi relacionados al folio fiscal.`.
+  `2001 - No Existen cfdi relacionados al folio fiscal.`. 
   Se ha modificado la prueba para que, si encuentra dicho error no rompa el ciclo de testeo y lo vuelva a intentar.
 
 ## Version 0.2.6 2020-01-24
@@ -108,7 +108,7 @@ Cambios en el entorno de pruebas (2020-09-18). Solo se afecta la rama principal,
 ## Version 0.2.5 2020-01-14
 
 - Se actualiza el año de licencia 2020.
-- Finkok implementó en el registro de clientes el método `switch`, para cambiar a el cliente de `Prepago`
+- Finkok implementó en el registro de clientes el método `switch`, para cambiar al cliente de `Prepago`
   a `Ondemand` y viceversa. Se ha creado el método y se incluyó en los helpers `Finkok` y `QuickFinkok`.
 - Se documentó el ticket de Finkok `#41435`: El acuse recibido en el método `get_reciept` es diferente que el
   obtenido en la respuesta de cancelación.
@@ -145,7 +145,7 @@ Cambios en el entorno de pruebas (2020-09-18). Solo se afecta la rama principal,
 
 ## Version 0.2.2 2019-11-02
 
-- Se agrega el soporte del servicio que obtiene la hora de los servidores de Finkok usando un código postal.
+- Se agrega el soporte del servicio que obtiene la hora de los servidores de Finkok usando un código postal. 
   Si no se especifica un código postal entonces se usa el predeterminado que corresponde a la zona horaria
   de `America/Mexico_City`. La hora devuelta no tiene especificación de zona horaria, es decir, no especifica
   cuánto tiempo hay de diferencia entre la hora devuelta y GMT.
@@ -186,4 +186,4 @@ BC Changes:
 
 ## Version 0.1.0 2019-09-04
 
-- Primer versión
+- Primera versión.

--- a/docs/Cancelación.md
+++ b/docs/Cancelación.md
@@ -8,14 +8,14 @@ Los servicios de paso son:
 - `cancel_signature`: Manda cancelar usando una solicitud de cancelación firmada.
 - `get_sat_status`: Consulta el estado de un CFDI.
 - `get_pending`: consultar cuantas solicitudes de cancelación tiene pendientes un receptor.
-- `accept_reject`: permite al receptor de una factura Aceptar o Rechazar una determinada cancelación.
-    (*no recomendado*, requiere certificado, llave privada y contraseña compártida)
-- `get_related`: obtener una lista de los UUIDs relacionados del CFDI que se está intentando cancelar.
-    (*no recomendado*, requiere certificado, llave privada y contraseña compártida)
+- `accept_reject`: permite al receptor de una factura Aceptar o Rechazar una determinada cancelación. 
+   (*no recomendado*, requiere certificado, llave privada y contraseña compártida)
+- `get_related`: obtener una lista de los UUID relacionados del CFDI que se está intentando cancelar. 
+   (*no recomendado*, requiere certificado, llave privada y contraseña compártida)
 
 Los servicios de ayuda son:
 
-- `cancel`: (*no recomendado*) Manda cancelar pero requiere del certificado, llave privada y contraseña compartida.
+- `cancel`: (*no recomendado*) Manda cancelar, pero requiere del certificado, llave privada y contraseña compartida. 
   La cancelación firmada la elabora Finkok en tu nombre y realiza `cancel_signature`.
 - `get_receipt`: Devuelve el acuse de recibo asociado a un UUID.
 - `query_pending_cancellation`: Consulta el *pending buffer*.
@@ -68,7 +68,7 @@ Si deseas usar esta característica, al enviar la solicitud de cancelación debe
 
 Siempre que uses el *Pending buffer* deberás utilizar el servicio `query_pending_cancellation`,
 que precísamente consulta el *pending buffer* para obtener el estado de la cancelación de una
-solicitud que se quedo pendiente de cancelar debido a una falla en el sistema de SAT.
+solicitud que se quedó pendiente de cancelar debido a una falla en el sistema de SAT.
 
 ### Cancelación de múltiples folios
 
@@ -126,10 +126,10 @@ En una prueba, estableciendo el valor de total a un valor incorrecto, la respues
 `CodigoEstatus: N 601 - La expresión impresa proporcionada no es válida.`, `Estado: Vigente` y
 `EsCancelable: Cancelable sin aceptación`. El problema es que `Estado` debería decir `No encontrado`.
 
-Desconozco porqué en los parámetros de consulta no se solicitan los últimos 8 caracteres del sello digital
+Desconozco por qué en los parámetros de consulta no se solicitan los últimos 8 caracteres del sello digital
 del emisor del comprobante (parte de la expresión impresa en `fe`). Esto indicaría que al PAC no le exigen
 todos los datos o bien el PAC los completa con la información que tiene del CFDI, en ese caso, me queda la
-duda de ¿porqué entonces no completa toda la expresión y requiere únicamente el UUID?.
+duda de ¿por qué entonces no completa toda la expresión y requiere únicamente el UUID?.
 
 ### Servicio Finkok Cancel get_pending
 
@@ -151,8 +151,8 @@ Suponiendo que se presenta la solicitud de cancelación por dos folios (A y B),
 donde A es cancelable sin autorización y B es no cancelable.
 
 - ¿El SAT responderá con un acuse de cancelación cancelando A (201), pero rechazando B (no_cancelable)?
-    R: Se desconoce, se podría hacer una prueba al respecto.
-    R: En la primer prueba realizada regresó estado de 201 para ambos CFDI, se está investigando
+    R: Se desconoce, se podría hacer una prueba al respecto. 
+    R: En la primera prueba realizada regresó estado de 201 para ambos CFDI, se está investigando. 
     R: La respuesta 201 significa que la *solicitud* fue recibida, no que el CFDI fue cancelado.
 
 Acerca del servicio `Get_Receipt`:
@@ -161,17 +161,16 @@ Acerca del servicio `Get_Receipt`:
     R: Finkok solo almacena los acuses positivos (estados 201 y 202).
 
 - ¿Cuál es el acuse de tipo "R - Recepción" y "C - Cancelación"?
-    R es el acuse de recepción de un CFDI timbrado.
+    R es el acuse de recepción de un CFDI timbrado. 
     C es el acuse de recepción de un CFDI cancelado.
 
 - Si se hubiera presentado la cancelación múltiples veces, se generaría un acuse de cancelación
-  por cada solicitud con estados `201` y `202`.
-  ¿Se devuelve sólo el último acuse con respuesta 202 o el acuse con respuesta 201 donde se canceló por primera vez?
-    R: Se devuelve sólo el último
+  por cada solicitud con estados `201` y `202`. 
+  ¿Se devuelve solo el último acuse con respuesta 202 o el acuse con respuesta 201 donde se canceló por primera vez?
+    R: Se devuelve solo el último.
 
 Para los servicios de pasarela, si no se pudo contactar al SAT, se devuelve `708`?
-    R: No, existen varios mensajes de error e incluso excepciones.
-    Finkok está analizando el tema para unificarlas.
+    R: No, existen varios mensajes de error e incluso excepciones. Finkok está analizando el tema para unificarlas.
 
 ### Servicios que requieren certificado, llave y contraseña compartida
 

--- a/docs/Ejemplos/ConsultarEstadoCFDI.md
+++ b/docs/Ejemplos/ConsultarEstadoCFDI.md
@@ -1,6 +1,6 @@
 # Ejemplo de consulta de estado de un CFDI
 
-Para estos ejemplo partiremos de que tenemos un CFDI en el archivo `cfdi.xml`.
+Para este ejemplo partiremos de que tenemos un CFDI en el archivo `cfdi.xml`.
 Y que los datos son: RFC emisor `EKU9003173C9`, RFC receptor `JES900109Q90`,
 total `12345.67` y UUID `11111111-2222-3333-4444-000000000001`.
 

--- a/docs/ListadoDeServicios.md
+++ b/docs/ListadoDeServicios.md
@@ -21,7 +21,7 @@ Servicios para trabajar con solicitudes de cancelación:
 
 - [X] `accept_reject_signature`: permite al receptor de una factura Aceptar o Rechazar una determinada cancelación.
 - [X] `get_pending`: consultar la lista de los UUID pendientes por cancelar que tiene el receptor.
-- [X] `get_related_signature`: obtener una lista de los UUIDs relacionados del CFDI que se está intentando cancelar.
+- [X] `get_related_signature`: obtener una lista de los UUID relacionados del CFDI que se está intentando cancelar.
 
 Servicios para trabajar cancelaciones con CFDI de otro PAC
 
@@ -44,7 +44,7 @@ Servicios para trabajar cancelaciones con CFDI de otro PAC
 - [X] `assign`: Asignar créditos a un cliente que va a timbrar bajo la cuenta de un socio de negocios de Finkok
 - [X] `add`: Agregar un cliente que va a timbrar bajo la cuenta de un socio de negocios de Finkok
 - [X] `edit`: Editar el estatus de un cliente, como lo es suspender o activar
-- [X] `get`: Listado o el status del RFC Emisor que este ingresando y tenga registrado en su cuenta
+- [X] `get`: Listado o el status del RFC Emisor que esté ingresando y tenga registrado en su cuenta
 - [X] `switch`: Cambia el tipo de cliente de prepago a ilimitado y viceversa
 
 ## Tokens
@@ -58,7 +58,7 @@ Servicios para trabajar cancelaciones con CFDI de otro PAC
 Estos servicios son de CFDI de retenciones e información de pagos (RET).
 
 - [X] `stamp`: Firma un CFDI RET, si fue firmado previamente retorna el timbrado previo.
-- [ ] `stamped`:  Regresa la información de un XML timbrado previamente.
+- [ ] `stamped`: Regresa la información de un XML timbrado previamente.
 - [ ] `cancel_signature`: Cancela un CFDI RET (el modelo de cancelación es el de CFDI 3.2).
 - [ ] `get_receipt`: Devuelve el acuse de recibo asociado a un UUID.
 

--- a/docs/PruebasDeIntegracion.md
+++ b/docs/PruebasDeIntegracion.md
@@ -1,4 +1,4 @@
-# Pruebas de integración.
+# Pruebas de integración
 
 Finkok requiere que tengas una cuenta con ellos. Por lo que es importante que tengas tus datos a la mano.
 

--- a/docs/PruebasDeIntegracion.md
+++ b/docs/PruebasDeIntegracion.md
@@ -6,7 +6,7 @@ Finkok requiere que tengas una cuenta con ellos. Por lo que es importante que te
 
 Para las pruebas se está utilizando el certificado de pruebas que corresponde a `ESCUELA KEMPER URGATE SA DE CV`
 [EKU9003173C9](https://wiki.finkok.com/lib/exe/fetch.php?media=csd_eku9003173c9_20190617131829.zip) y caduca
-`2023-06-17`, antes se estaba usando TCM970625MB1 pero el SAT lo ha revocado.
+`2023-06-17`, antes se estaba usando TCM970625MB1, pero el SAT lo ha revocado.
 
 Los datos se encuentran en `tests/_files/certs/`:
 

--- a/docs/RegistroDeClientes.md
+++ b/docs/RegistroDeClientes.md
@@ -40,8 +40,8 @@ No genera error si se intenta cambiar al estado actual (ilimitado a ilimitado, o
 
 ## Parámetros username/password
 
-Finkok considera una buena idea que para los métodos add, edit y get los parámetros de usuario y contraseña
-no son username/password como los demás. Los parámetros en estos casos son username_reseller/password_reseller.
+Finkok considera una buena idea que para los métodos `add`, `edit` y `get` los parámetros de usuario y contraseña
+no son username/password como los demás. Los parámetros en estos casos son `username_reseller/password_reseller`.
 
 Pero, para los métodos assign y switch, los parámetros sí son username/password.
 
@@ -51,7 +51,7 @@ No existe método para eliminar un cliente (Ticket #19372)
 
 No funciona la eliminación de un cliente en el portal de finkok (Ticket #19524)
 
-Por las respuestas en los tickets, no hay una explicación de porqué no se puede eliminar
+Por las respuestas en los tickets, no hay una explicación de por qué no se puede eliminar
 (la única razón es "nuestras políticas internas de diseño y desarrollo de Finkok")
 y confirman que no se puede (ni se podrá) eliminar un cliente, ni por webservice ni por el portal.
 

--- a/docs/Servicios.md
+++ b/docs/Servicios.md
@@ -24,8 +24,8 @@ Nunca compartas tus certificados y llaves privadas, ni con tu PAC.
 
 ## Entornos de producción y pruebas
 
-Otra característica importante es que Finkok tiene dos entornos de trabajo y cada uno tiene sus
-réplica de los servicios que ofrece.
+Otra característica importante es que Finkok tiene dos entornos de trabajo
+y en cada uno tiene su réplica de los servicios que ofrece.
 
 - Producción: `https://facturacion.finkok.com`
 - Pruebas: `https://demo-facturacion.finkok.com`

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6,7 +6,7 @@
 - Investigar cómo validar firma en acuses y respuestas del SAT
 
 - Crear un namespace común porque hay clases que están interrelacionadas entre el estampado y cancelación
-  de cfdi y de retenciones. Así como las clases abstractas de colecciones y resultados.
+  de cfdi y de retenciones. Así como las clases abstractas de colecciones y resultados. 
   Esto creará una incompatilidad con versiones previas.
 
 - Agregar la integración de CFDI de retenciones y pagos
@@ -17,11 +17,11 @@
 
 - La forma en que están hechos los objetos result es mezclada, algunas propiedades las obtiene cuando se solicitan
   y otras propiedades las obtiene en la creación del objeto. El problema es que se guarda la referencia al objeto
-  stdClass de entrada, por lo que podría ser manipulado externamente y devolver resultados diferentes.
+  stdClass de entrada, por lo que podría ser manipulado externamente y devolver resultados diferentes. 
   Esto al fin de cuentas es un error de consistencia, pues o bien todas las propiedades se deben establecer en
-  el constructor o bien las propiedades deben consultarse al momento de leerlas.
-  La primera opción genera duplicidad de memoria (los valores están en el objeto result copiados del input).
-  La segunda opción genera mutabilidad al poderse manipular el input.
+  el constructor o bien las propiedades deben consultarse al momento de leerlas. 
+  La primera opción genera duplicidad de memoria (los valores están en el objeto result copiados del input). 
+  La segunda opción genera mutabilidad al poderse manipular el input. 
   La tercera opción es no permitir manipular en input una vez que está dentro del resultado.
 
 - Fortalecer los comandos como DownloadXml (get_xml) que el tipo solo puede ser I - CFDI o R - Retenciones
@@ -30,8 +30,8 @@
 
 - AcceptRejectSigner debería permitir aceptar y/o rechazar más de 1 solo UUID a la vez
 
-- Agregar un caso para hacer una prueba positiva de AcceptRejectSignatureService.
-  Para hacer esta prueba se requieren 2 RFC (A y B), en este momento solo tenemos 1.
+- Agregar un caso para hacer una prueba positiva de AcceptRejectSignatureService. 
+  Para hacer esta prueba se requieren 2 RFC (A y B), en este momento solo tenemos 1. 
   Crear un CFDI donde A es Emisor y B es Receptor que requiera autorización (por ejemplo, por monto)
   A hace la solicitud de cancelación
   B hace la consulta de pendientes y ve el UUID
@@ -40,7 +40,7 @@
   Se consulta el estado del UUID y está cancelado
 
 - Las pruebas de servicios no están verificando a dónde se está enviando la solicitud, por lo que podría existir un
-  error al crear el endpoint, el error saldría a la luz en pruebas de integración pero no en pruebas unitarias.
+  error al crear el endpoint, el error saldría a la luz en pruebas de integración pero no en pruebas unitarias. 
   Se puede agregar un código como el siguiente (en `...\Tests\Unit\Services\Retentions\CancelSignatureServiceTest`):
   `$this->assertStringEndsWith(Services::retentions()->value(), $soapFactory->latestWsdlLocation);`
 

--- a/docs/issues/AcuseCancelacionNoCoincidente.md
+++ b/docs/issues/AcuseCancelacionNoCoincidente.md
@@ -1,4 +1,4 @@
-# El acuse de cancelación no coincide
+# El acuse de cancelación entregado al cancelar y al solicitar el acuse no coinciden
 
 > *Este error de encuenta solucionado*
 

--- a/docs/issues/AcuseCancelacionNoCoincidente.md
+++ b/docs/issues/AcuseCancelacionNoCoincidente.md
@@ -28,7 +28,7 @@ CFDI fuese cancelado, el acuse contiene solamente la respuesta a la petición pr
 y se publicará la actualización a pesar de este error, si Finkok decidiera no actualizar su servicio entonces
 se eliminará la comprobación en el test de integración.
 
-2019-01-15: Se confirmó que se sufría de un bug de carrera, cuando se solicita el acuse pero aun no ha sido almacenado
+2019-01-15: Se confirmó que se sufría de un bug de carrera, cuando se solicita el acuse, pero aún no ha sido almacenado
 entonces se devuelve un acuse "fabricado". El problema lo tenían al fabricarlo y esto ha sido corregido.
 Personalmente considero que, al tratarse de un documento "oficial" con firma XML, deberían evitar fabricarlo y mejor
 retornar un error de tipo "Acuse no disponible en este momento, intente más tarde".

--- a/docs/issues/CancelSignatureServiceCancelarRecienCreado.md
+++ b/docs/issues/CancelSignatureServiceCancelarRecienCreado.md
@@ -5,7 +5,7 @@ El servicio [`Cancel_Signature`](https://wiki.finkok.com/doku.php?id=cancelsigne
 *realiza la cancelación de un comprobante CFDI por medio de un XML desarrollado como la firma*.
 
 Al llamar a la cancelación con una firma válida para un CFDI recién creado,
-con el el parámetro `store_pending` en `false`,
+con el parámetro `store_pending` en `false`,
 se encuentra con una respuesta `205` en lugar de la esperada `201`.
 No importa si se creó el timbre usando `quick_stamp` o `stamp`.
 
@@ -197,7 +197,7 @@ El servicio de cancelación funciona como un puente con el SAT, entre otras cosa
 abierto el servicio al público en general, solo a los PAC.
 
 El error 205 no lo reporta Finkok, lo reporta el SAT (se puede ver en el acuse). Lo que lleva a preguntarnos:
-¿Porqué entonces el SAT responde con Vigente/Cancelable en el servicio de consulta, y luego response con 205?
+¿Por qué entonces el SAT responde con Vigente/Cancelable en el servicio de consulta, y luego response con 205?
 Porque es el SAT. Lo más probable es que por un lado almacene los CFDI y los ingrese en varios repositorios de
 información, y por otros lugares consume esos repositorios. Luego entonces, el servicio de estado podría
 retornar que sí existe y está vigente mientras que el servicio de cancelación podría decir que no existe.

--- a/docs/issues/CancelSignatureServiceCancelarRecienCreado.md
+++ b/docs/issues/CancelSignatureServiceCancelarRecienCreado.md
@@ -1,3 +1,4 @@
+# Cancelación de un CFDI recién creado
 
 ## Descripción
 

--- a/docs/issues/CancelacionRetencionesCodEstatus.md
+++ b/docs/issues/CancelacionRetencionesCodEstatus.md
@@ -1,4 +1,4 @@
-# `CodEstatus` ausente en la cancelación de CFDI de Retenciones
+# El valor `CodEstatus` está ausente en la cancelación de CFDI de Retenciones
 
 Según el WebService de cancelación de retenciones (demo[1]() y producción[2]())
 así como en la documentación[3]() debería retornar estructura con

--- a/docs/issues/CancelacionRetencionesCodEstatus.md
+++ b/docs/issues/CancelacionRetencionesCodEstatus.md
@@ -1,5 +1,8 @@
 # El valor `CodEstatus` está ausente en la cancelación de CFDI de Retenciones
 
+**2021-06-08**: `CodEstatus` solo está presente si se envía un valor incorrecto en la petición,
+o el código del SAT cuando presenta intermitencias. El problema se marca como finalizado.
+
 Según el WebService de cancelación de retenciones (demo[1]() y producción[2]())
 así como en la documentación[3]() debería retornar estructura con
 `CodEstatus - El código de respuesta del SAT`.
@@ -99,3 +102,11 @@ X-Content-Type-Options: nosniff
 [1] https://demo-facturacion.finkok.com/servicios/soap/retentions.wsdl
 [2] https://facturacion.finkok.com/servicios/soap/retentions.wsdl
 [3] https://wiki.finkok.com/doku.php?id=cancel_signature_method_retentions
+
+## Respuesta
+
+Se corrigió la documentación del servicio.
+
+- El campo de respuesta `CodEstatus` solo está presente si se envía un valor incorrecto en la petición,
+  o el código del SAT cuando presenta intermitencias.
+- El campo de respuesta `SeguimientoCancelacion` solo está presente si se envía más de un UUID a cancelar.

--- a/docs/issues/CancelacionRetencionesError1308.md
+++ b/docs/issues/CancelacionRetencionesError1308.md
@@ -1,4 +1,4 @@
-# Cancelacion de Retenciones con error 1308
+# Error de cancelación de retenciones 1308 - Certificado revocado o caduco
 
 Al momento de hacer pruebas de integración sobre el servicio de cancelación de CFDI de tipo retenciones e información
 de pagos, se encuentra que al enviar la solicitud el servidor de pruebas del SAT responde en `CodEstatus` el

--- a/docs/issues/CancelacionRetencionesError1308.md
+++ b/docs/issues/CancelacionRetencionesError1308.md
@@ -5,7 +5,7 @@ de pagos, se encuentra que al enviar la solicitud el servidor de pruebas del SAT
 error `1308 - Certificado revocado o caduco`.
 
 Se ha reportado a Finkok con el [ticket #41610](https://support.finkok.com/support/tickets/41610) donde nos pudieron
-responder ciertos cuestionamientos pero el problema sigue sin resolverse:
+responder ciertos cuestionamientos, pero el problema sigue sin resolverse:
 
 - ¿Hay algún RFC en especial que deba utilizar para poder hacer pruebas de CFDI de retenciones y pagos?
 
@@ -15,7 +15,7 @@ al utilizar cualquiera de los RFC que se tienen publicados en el wiki y que ello
 
 - ¿Por qué está devolviendo el código 1308?
 
-Al parecer la incidencia se presenta por que el SAT no tiene habilitados los RFC de prueba.
+Al parecer la incidencia se presenta porque el SAT no tiene habilitados los RFC de prueba.
 
 - Si es un error del SAT, ¿se ha reportado?
 

--- a/docs/issues/QueryPendingServiceUuidNoExistente.md
+++ b/docs/issues/QueryPendingServiceUuidNoExistente.md
@@ -1,4 +1,4 @@
-# Servicio `QueryPending` sin `UUID`
+# Consumir `queryPending` con un CFDI recién creado
 
 ## Descripción
 

--- a/docs/issues/QueryPendingServiceUuidNoExistente.md
+++ b/docs/issues/QueryPendingServiceUuidNoExistente.md
@@ -1,8 +1,9 @@
+# Servicio `QueryPending` sin `UUID`
 
 ## Descripción
 
 El servicio [`Query_Pending`](https://wiki.finkok.com/doku.php?id=query_pending) *se usa para consultar el
-estatus de una factura que se quedo pendiente de enviar al SAT debido a una falla en el sistema del SAT
+estatus de una factura que se quedó pendiente de enviar al SAT debido a una falla en el sistema del SAT
 o bien que se envió a través del método `Quick_Stamp`*.
 
 Por lo tanto, se podría llegar a ocupar con cualquier método de estampado.
@@ -61,7 +62,7 @@ x-frame-options: DENY
 Set-Cookie: sessionid=2f06b59dbf811e2b68be49a930692fe7; httponly; Path=/; secure
 ```
 
-- Response body (se omiten namespaces que devuelve pero no se usan)
+- Response body (se omiten namespaces que devuelve, pero no se usan)
 
 ```xml
 <?xml version='1.0' encoding='UTF-8'?>

--- a/docs/issues/StampServiceDobleEstampado.md
+++ b/docs/issues/StampServiceDobleEstampado.md
@@ -1,3 +1,4 @@
+# Consumir `stamp` para generar un doble estampado no devuelve los datos
 
 ## Descripción
 

--- a/docs/issues/StampServiceDobleEstampado.md
+++ b/docs/issues/StampServiceDobleEstampado.md
@@ -19,8 +19,8 @@ Y en <https://wiki.finkok.com/doku.php?id=stamp#ejemplo_de_una_respuesta_con_err
 
 La respuesta no contiene la información del UUID timbrado previamente.
 
-En su lugar contiene un `stampResult` con `Incidencia:CodigoError` `307`, el `xml` está vacío.
-Los demás valores no son reportados. Es un misterio para mí porqué retorna dos veces la incidencia.
+En su lugar contiene un `stampResult` con `Incidencia:CodigoError` `307`, el valor de `xml` está vacío.
+Los demás valores no son reportados. Es un misterio para mí por qué retorna dos veces la incidencia.
 
 ```json
 {
@@ -68,7 +68,7 @@ Esto parece dar más claridad al error:
     - `stamp`: Algunas veces lo encuentra y lo devuelve
 
 Por lo tanto, parece que en realidad el problema consiste en que internamente Finkok
-sí reporta que el CFDI fue creado pero no lo pone a disposición para poderlo recuperar.
+sí reporta que el CFDI fue creado, pero no lo pone a disposición para poderlo recuperar.
 
 Incluso he creado un test que encadena las pruebas, en resumen:
 llama a `stamp` por primera vez,
@@ -79,7 +79,7 @@ Y lo que sucede es que algunas veces el segundo estampado sigue sin contener los
 
 ### Servicios afectados
 
-- `stamp`: al menos reporta que el CFDI ya fue timbrado)
+- `stamp`: al menos reporta que el CFDI ya fue timbrado.
 - `stamped`: incluso dice que el CFDI no ha sido timbrado con anterioridad.
 
 El servicio `quick_stamp` se salva de esta cuestión porque establece que en caso de haber un estampado previo
@@ -95,9 +95,9 @@ entonces se devolverá un código `307` y ya. No se espera que devuelva el conte
 Han modificado su documentación -*¡zorro astuto!*- y este es el comportamiento esperado:
 
 > Al llamar a stamp dos veces con el mismo precfdi, la segunda vez puede regresar
-> *o puede no regresar* los datos del cfdi previamente firmado.
+> *o puede no regresar* los datos del cfdi firmado previamente.
 
-Por lo que, al menos para el método `stamp`, que no regrese el `xml` o `uuid` es considerado dentro de lo esperado.
+Por lo que, al menos para el método `stamp`, que no regrese el contenido `xml` o `uuid` es considerado dentro de lo esperado.
 
 Para el método `stamped` es otra historia, porque el error devuelto por este método es una incidencia
 `603: El CFDI no contiene un timbre previo`.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,7 @@
     executionOrder="depends,defects"
     failOnRisky="true"
     failOnWarning="true"
+    convertDeprecationsToExceptions="true"
     verbose="true"
     colors="true">
 

--- a/tests/Integration/Services/Retentions/CancelSignatureServiceTest.php
+++ b/tests/Integration/Services/Retentions/CancelSignatureServiceTest.php
@@ -59,7 +59,7 @@ final class CancelSignatureServiceTest extends RetentionsTestCase
         $this->assertNotEmpty($result->voucher(), 'Expected to receive an Acuse, but it was empty');
         $this->assertEmpty(
             $result->statusCode(),
-            'CodEstatus is not empty anymore, check https://support.finkok.com/support/tickets/49417'
+            'CodEstatus should have content only when command has incorrect values or SAT service is failing'
         );
         $this->assertSame($uuid, $document->uuid());
         $this->assertSame('1201', $document->documentStatus());


### PR DESCRIPTION
- Fix broken CI. PHPUnit 9.5.10 does not convert deprecations to exceptions by default.
- Fix CoC email.
- A lot of titles, grammar and typos.
- Default branch was renamed from `master` to `main`.
