### PR TITLE
Actualizar cancelaciones 2022 (Version 0.4.0)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,7 @@
 
 # Do not put this files on a distribution package
 /.github/                   export-ignore
+/.phive/                    export-ignore
 /build/                     export-ignore
 /tests/                     export-ignore
 /.gitattributes             export-ignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           extensions: json, soap, dom, openssl
           coverage: none
-          tools: composer:v2, cs2pr
+          tools: composer:v2, cs2pr, phpcs, php-cs-fixer, phpstan
         env:
           fail-fast: true
 
@@ -46,13 +46,13 @@ jobs:
         run: composer upgrade --no-interaction --no-progress --prefer-dist
 
       - name: Code style (phpcs)
-        run: vendor/bin/phpcs -q --report=checkstyle src/ tests/ | cs2pr
+        run: phpcs -q --report=checkstyle | cs2pr
 
       - name: Code style (php-cs-fixer)
-        run: vendor/bin/php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
+        run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
 
       - name: Unit tests (phpunit)
         run: vendor/bin/phpunit tests/Unit/ --testdox --verbose
 
       - name: Code analysis (phpstan)
-        run: vendor/bin/phpstan analyse --level max --no-progress --verbose src/ tests/
+        run: phpstan analyse --no-progress --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # do not include this files on git
 .env
 /vendor/
+/tools/
 /composer.lock

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phive xmlns="https://phar.io/phive">
+  <phar name="phpcs" version="^3.6.2" installed="3.6.2" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.6.2" installed="3.6.2" location="./tools/phpcbf" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.4.0" installed="3.4.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpstan" version="^1.3.3" installed="1.3.3" location="./tools/phpstan" copy="false"/>
+</phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,50 +1,52 @@
 <?php
 
+/**
+ * @noinspection PhpUndefinedClassInspection
+ * @noinspection PhpUndefinedNamespaceInspection
+ * @see https://cs.symfony.com/doc/ruleSets/
+ * @see https://cs.symfony.com/doc/rules/
+ */
+
 declare(strict_types=1);
 
-return ( new PhpCsFixer\Config())
+return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
-    ->setCacheFile(__DIR__ . '/build/.php_cs.cache')
+    ->setCacheFile(__DIR__ . '/build/php_cs.cache')
     ->setRules([
-        '@PSR2' => true,
-        '@PHP70Migration' => true,
-        '@PHP70Migration:risky' => true,
-        '@PHP71Migration' => true,
+        '@PSR12' => true,
+        '@PSR12:risky' => true,
         '@PHP71Migration:risky' => true,
+        '@PHP73Migration' => true,
+        // PSR12 (remove when php-cs-fixer reaches ^3.1.1)
+        'class_definition' => ['space_before_parenthesis' => true],
         // symfony
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
-        'no_alias_functions' => true,
-        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
-        'new_with_braces' => true,
-        'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
         'phpdoc_scalar' => true,
-        'self_accessor' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'single_quote' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_unused_imports' => true,
-        'no_whitespace_in_blank_line' => true,
         'yoda_style' => ['equal' => true, 'identical' => true, 'less_and_greater' => null],
         'standardize_not_equals' => true,
-        // contrib
         'concat_space' => ['spacing' => 'one'],
-        'not_operator_with_successor_space' => true,
-        'single_blank_line_before_namespace' => true,
         'linebreak_after_opening_tag' => true,
-        'blank_line_after_opening_tag' => true,
-        'ordered_imports' => true,
-        'array_syntax' => ['syntax' => 'short'],
+        // symfony:risky
+        'no_alias_functions' => true,
+        'self_accessor' => true,
+        // contrib
+        'not_operator_with_successor_space' => true,
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->in(__DIR__)
-            ->exclude(['vendor', 'build'])
+            ->append([__FILE__])
+            ->exclude(['vendor', 'tools', 'build'])
     )
 ;

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -2,6 +2,7 @@ filter:
   excluded_paths:
     - 'tests/'
     - 'vendor/'
+    - 'tools/'
 
 # see https://scrutinizer-ci.com/docs/tools/php/php-scrutinizer/
 build:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 - 2021 PhpCfdi https://www.phpcfdi.com
+Copyright (c) 2019 - 2022 PhpCfdi https://www.phpcfdi.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "psr/log": "^1.1",
         "eclipxe/enum": "^0.2.0",
         "phpcfdi/credentials": "^1.0.1",
-        "phpcfdi/xml-cancelacion": "^2.0.0",
+        "phpcfdi/xml-cancelacion": "^2.0.1",
         "robrichards/xmlseclibs": "^3.0.4",
         "eclipxe/micro-catalog": "^0.1.0",
         "phpcfdi/cfdi-expresiones": "^3.0"

--- a/composer.json
+++ b/composer.json
@@ -40,10 +40,7 @@
         "ext-fileinfo": "*",
         "symfony/dotenv": "^5.1",
         "eclipxe/cfdiutils": "^2.15",
-        "phpunit/phpunit": "^9.5.10",
-        "squizlabs/php_codesniffer": "^3.6",
-        "friendsofphp/php-cs-fixer": "^3.0",
-        "phpstan/phpstan": "^0.12.54"
+        "phpunit/phpunit": "^9.5.10"
     },
     "autoload": {
         "psr-4": {
@@ -58,16 +55,16 @@
     "scripts": {
         "dev:build": ["@dev:fix-style", "@dev:check-style", "@dev:test"],
         "dev:check-style": [
-            "@php vendor/bin/php-cs-fixer fix --dry-run --verbose",
-            "@php vendor/bin/phpcs --colors -sp src/ tests/"
+            "@php tools/php-cs-fixer fix --dry-run --verbose",
+            "@php tools/phpcs --colors -sp"
         ],
         "dev:fix-style": [
-            "@php vendor/bin/php-cs-fixer fix --verbose",
-            "@php vendor/bin/phpcbf --colors -sp src/ tests/"
+            "@php tools/php-cs-fixer fix --verbose",
+            "@php tools/phpcbf --colors -sp"
         ],
         "dev:test": [
             "@php vendor/bin/phpunit --testdox --verbose --stop-on-failure tests/Unit",
-            "@php vendor/bin/phpstan analyse --no-progress --verbose --level max src/ tests/"
+            "@php tools/phpstan analyse --no-progress --verbose"
         ],
         "dev:coverage": [
             "@php -dzend_extension=xdebug.so vendor/bin/phpunit --verbose --coverage-html build/coverage/html/"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "psr/log": "^1.1",
         "eclipxe/enum": "^0.2.0",
         "phpcfdi/credentials": "^1.0.1",
-        "phpcfdi/xml-cancelacion": "^1.1.0",
+        "phpcfdi/xml-cancelacion": "^2.0.0",
         "robrichards/xmlseclibs": "^3.0.4",
         "eclipxe/micro-catalog": "^0.1.0",
         "phpcfdi/cfdi-expresiones": "^3.0"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,11 +2,24 @@
 
 Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor el control de versiones.
 
-## Pendientes para siguiente versión mayor
+## Version 0.4.0 2022-01-09
 
-- Eliminar `CancelledDocument::cancellationSatatus()`.
+Se actualiza a [`phpcfdi/xml-cancelacion`](https://github.com/phpcfdi/xml-cancelacion) que incluye los
+formatos a utilizar para la cancelación 2022 según la nueva especificación del SAT.
+Esto provoca cambios importantes en todos los métodos relacionados con la cancelación.
 
-## Unreleased
+Se elimina `CancelledDocument::cancellationSatatus()`. Se debe usar `CancelledDocument::cancellationStatus()`.
+
+Se actualiza la licencia a 2022. ¡Feliz año!
+
+Se hacen varios cambios al entorno de desarrollo:
+
+- Se agregan nuevos casos para el error de estampado `707`.
+- Se cambian las dependencias de desarrollo a `phive`.
+- Ya no se usa `\getenv`, en su lugar se pone una función segura en `TestCase::getenv`.
+- Se corrigen las incidencias encontradas por PHPStan 1.3.3.
+
+Se incluyen los cambios previos no liberados en una versión:
 
 - 2021-09-26: Fix broken CI. PHPUnit 9.5.10 does not convert deprecations to exceptions by default.
 

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -23,7 +23,7 @@ Esto significa que:
 - no debe actualizar a versiones `3.x.x`
 - no debe utilizar ninguna versión menor a `2.5.0`
 
-## Versiones 0.x.y no rompe compatibilidad
+## Versiones 0.x.y no rompen compatibilidad
 
 Las versiones que inician con cero, por ejemplo `0.y.z`, no se ajustan a las reglas de versionado.
 Se considera que estas versiones son previas a la madurez del proyecto y por lo tanto

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,15 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="EngineWorks">
     <description>The EngineWorks (PSR-2 based) coding standard.</description>
+
+    <file>src</file>
+    <file>tests</file>
+
     <arg name="tab-width" value="4"/>
     <arg name="encoding" value="utf-8"/>
     <arg name="report-width" value="auto"/>
     <arg name="extensions" value="php"/>
-    <rule ref="PSR2"/>
+    <arg name="cache" value="build/phpcs.cache"/>
+
+    <rule ref="PSR12"/>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
     <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
     <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>
     <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
+    <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
     <rule ref="Generic.Formatting.SpaceAfterNot"/>
     <rule ref="Generic.Functions.CallTimePassByReference"/>
     <rule ref="Generic.NamingConventions.ConstructorName"/>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,3 +1,5 @@
 parameters:
-    inferPrivatePropertyTypeFromConstructor: true
-
+    level: max
+    paths:
+        - src/
+        - tests/

--- a/src/Definitions/CancelAnswer.php
+++ b/src/Definitions/CancelAnswer.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace PhpCfdi\Finkok\Definitions;
 
 /**
- * Define the answer to the cancellation request (accept/reject)
+ * Define the answer to the cancellation request (to accept or reject)
  *
  * @method static self accept()
  * @method static self reject()
  * @method bool isAccept()
  * @method bool isReject()
  */
-class CancelAnswer extends \PhpCfdi\XmlCancelacion\Definitions\CancelAnswer
+class CancelAnswer extends \PhpCfdi\XmlCancelacion\Models\CancelAnswer
 {
 }

--- a/src/Definitions/RfcRole.php
+++ b/src/Definitions/RfcRole.php
@@ -12,6 +12,6 @@ namespace PhpCfdi\Finkok\Definitions;
  * @method bool isIssuer()
  * @method bool isReceiver()
  */
-class RfcRole extends \PhpCfdi\XmlCancelacion\Definitions\RfcRole
+class RfcRole extends \PhpCfdi\XmlCancelacion\Models\RfcRole
 {
 }

--- a/src/Finkok.php
+++ b/src/Finkok.php
@@ -41,7 +41,7 @@ use PhpCfdi\Finkok\Services\Utilities;
  */
 class Finkok
 {
-    /** @var array<array> */
+    /** @var array<string, string[]> */
     protected const SERVICES_MAP = [
         'stamp' => [Stamping\StampService::class, Stamping\StampingCommand::class],
         'quickstamp' => [Stamping\QuickStampService::class, Stamping\StampingCommand::class],
@@ -120,10 +120,12 @@ class Finkok
      */
     protected function checkCommand(string $method, $command): ?object
     {
+        /** @var class-string|string $expected */
         $expected = static::SERVICES_MAP[$method][1];
         if ('' === $expected) {
             return null;
         }
+        /** @var object|string $command */
         if (! is_a($command, $expected)) {
             $type = (is_object($command)) ? get_class($command) : gettype($command);
             throw new InvalidArgumentException(

--- a/src/Helpers/CancelSigner.php
+++ b/src/Helpers/CancelSigner.php
@@ -7,12 +7,13 @@ namespace PhpCfdi\Finkok\Helpers;
 use DateTimeImmutable;
 use PhpCfdi\Credentials\Credential;
 use PhpCfdi\XmlCancelacion\Credentials as XmlCancelacionCredentials;
+use PhpCfdi\XmlCancelacion\Models\CancelDocuments;
 use PhpCfdi\XmlCancelacion\XmlCancelacionHelper;
 
 class CancelSigner
 {
-    /** @var array<string> */
-    private $uuids;
+    /** @var CancelDocuments*/
+    private $documents;
 
     /** @var DateTimeImmutable */
     private $dateTime;
@@ -20,19 +21,19 @@ class CancelSigner
     /**
      * CancelSigner constructor
      *
-     * @param array<string> $uuid
+     * @param CancelDocuments $documents
      * @param DateTimeImmutable|null $dateTime If null or ommited then use current time and time zone
      */
-    public function __construct(array $uuid, ?DateTimeImmutable $dateTime = null)
+    public function __construct(CancelDocuments $documents, ?DateTimeImmutable $dateTime = null)
     {
-        $this->uuids = $uuid;
+        $this->documents = $documents;
         $this->dateTime = $dateTime ?? new DateTimeImmutable();
     }
 
-    /** @return array<string> */
-    public function uuids(): array
+    /** @return CancelDocuments */
+    public function documents(): CancelDocuments
     {
-        return $this->uuids;
+        return $this->documents;
     }
 
     public function dateTime(): DateTimeImmutable
@@ -43,12 +44,12 @@ class CancelSigner
     public function sign(Credential $credential): string
     {
         $helper = new XmlCancelacionHelper(XmlCancelacionCredentials::createWithPhpCfdiCredential($credential));
-        return $helper->signCancellationUuids($this->uuids(), $this->dateTime());
+        return $helper->signCancellationUuids($this->documents(), $this->dateTime());
     }
 
     public function signRetention(Credential $credential): string
     {
         $helper = new XmlCancelacionHelper(XmlCancelacionCredentials::createWithPhpCfdiCredential($credential));
-        return $helper->signRetentionCancellationUuids($this->uuids(), $this->dateTime());
+        return $helper->signRetentionCancellationUuids($this->documents(), $this->dateTime());
     }
 }

--- a/src/QuickFinkok.php
+++ b/src/QuickFinkok.php
@@ -16,6 +16,8 @@ use PhpCfdi\Finkok\Services\Registration;
 use PhpCfdi\Finkok\Services\Retentions;
 use PhpCfdi\Finkok\Services\Stamping;
 use PhpCfdi\Finkok\Services\Utilities;
+use PhpCfdi\XmlCancelacion\Models\CancelDocument;
+use PhpCfdi\XmlCancelacion\Models\CancelDocuments;
 
 class QuickFinkok
 {
@@ -120,14 +122,14 @@ class QuickFinkok
      * Durante el proceso no se envía ningún CSD a Finkok y la solicitud firmada es creada usando los datos del CSD
      *
      * @param Credential $credential
-     * @param string $uuid
+     * @param CancelDocument $document
      * @return Cancel\CancelSignatureResult
      * @see https://wiki.finkok.com/doku.php?id=cancelsigned_method
      * @see https://wiki.finkok.com/doku.php?id=cancel_method
      */
-    public function cancel(Credential $credential, string $uuid): Cancel\CancelSignatureResult
+    public function cancel(Credential $credential, CancelDocument $document): Cancel\CancelSignatureResult
     {
-        $signer = new Helpers\CancelSigner([$uuid]);
+        $signer = new Helpers\CancelSigner(new CancelDocuments($document));
         $signedRequest = $signer->sign($credential);
         $command = new Cancel\CancelSignatureCommand($signedRequest);
         $service = new Cancel\CancelSignatureService($this->settings());
@@ -531,14 +533,14 @@ class QuickFinkok
      * Durante el proceso no se envía ningún CSD a Finkok y la solicitud firmada es creada usando los datos del CSD
      *
      * @param Credential $credential
-     * @param string $uuid
+     * @param CancelDocument $document
      * @return Retentions\CancelSignatureResult
      * @see https://wiki.finkok.com/doku.php?id=cancel_signature_method_retentions
      * @see https://wiki.finkok.com/doku.php?id=cancel_method_retentions
      */
-    public function retentionCancel(Credential $credential, string $uuid): Retentions\CancelSignatureResult
+    public function retentionCancel(Credential $credential, CancelDocument $document): Retentions\CancelSignatureResult
     {
-        $signer = new Helpers\CancelSigner([$uuid]);
+        $signer = new Helpers\CancelSigner(new CancelDocuments($document));
         $signedRequest = $signer->signRetention($credential);
         $command = new Retentions\CancelSignatureCommand($signedRequest);
         $service = new Retentions\CancelSignatureService($this->settings());

--- a/src/Services/Cancel/CancelledDocument.php
+++ b/src/Services/Cancel/CancelledDocument.php
@@ -31,20 +31,6 @@ class CancelledDocument
         return $this->get('EstatusUUID');
     }
 
-    /**
-     * @return string
-     * @deprecated 0.3.2
-     * @see self::cancellationStatus
-     */
-    public function cancellationSatatus(): string
-    {
-        trigger_error(
-            sprintf('%s is deprecated since 0.3.2 and will be removed on 0.4.0', __METHOD__),
-            E_USER_DEPRECATED
-        );
-        return $this->cancellationStatus();
-    }
-
     public function cancellationStatus(): string
     {
         return $this->get('EstatusCancelacion');

--- a/src/Services/Utilities/ReportCreditResult.php
+++ b/src/Services/Utilities/ReportCreditResult.php
@@ -9,7 +9,7 @@ use stdClass;
 
 class ReportCreditResult extends AbstractResult
 {
-    /** @var array[] */
+    /** @var array<array{credit: string, date: string}> */
     private $items;
 
     public function __construct(stdClass $data)
@@ -29,7 +29,7 @@ class ReportCreditResult extends AbstractResult
         }
     }
 
-    /** @return array[] */
+    /** @return array<array{credit: string, date: string}> */
     public function items(): array
     {
         return $this->items;

--- a/src/Services/Utilities/ReportTotalResult.php
+++ b/src/Services/Utilities/ReportTotalResult.php
@@ -21,6 +21,7 @@ class ReportTotalResult extends AbstractResult
     public function __construct(stdClass $data)
     {
         parent::__construct($data, 'report_totalResult');
+        /** @var array{stdClass|null} $items */
         $items = $this->findInDescendent($data, 'report_totalResult', 'result', 'ReportTotal') ?? [];
         $result = $items[0] ?? (object) [];
         $this->rfc = $result->taxpayer_id ?? '';

--- a/src/Services/Utilities/ReportUuidResult.php
+++ b/src/Services/Utilities/ReportUuidResult.php
@@ -9,7 +9,7 @@ use stdClass;
 
 class ReportUuidResult extends AbstractResult
 {
-    /** @var array[] */
+    /** @var array<int, array{date: string, uuid:string}> */
     private $items;
 
     public function __construct(stdClass $data)
@@ -32,7 +32,7 @@ class ReportUuidResult extends AbstractResult
     /**
      * The returned array contains an array with keys date (string) and uuid (string)
      *
-     * @return array[]
+     * @return array<int, array{date: string, uuid:string}>
      */
     public function items(): array
     {

--- a/src/SoapCaller.php
+++ b/src/SoapCaller.php
@@ -59,6 +59,7 @@ class SoapCaller implements LoggerAwareInterface
             $this->logger->debug(strval(json_encode([
                 $methodName => $this->extractSoapClientTrace($soap),
             ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)));
+            /** @var stdClass $result */
             return $result;
         } catch (Throwable $exception) {
             $this->logger->error(strval(json_encode(
@@ -77,10 +78,10 @@ class SoapCaller implements LoggerAwareInterface
     protected function extractSoapClientTrace(SoapClient $soapClient): array
     {
         return [
-            'request.headers' => @$soapClient->__getLastRequestHeaders(),
-            'request.body' => @$soapClient->__getLastRequest(),
-            'response.headers' => @$soapClient->__getLastResponseHeaders(),
-            'response.body' => @$soapClient->__getLastResponse(),
+            'request.headers' => (string) @$soapClient->__getLastRequestHeaders(),
+            'request.body' => (string) @$soapClient->__getLastRequest(),
+            'response.headers' => (string) @$soapClient->__getLastResponseHeaders(),
+            'response.body' => (string) @$soapClient->__getLastResponse(),
         ];
     }
 

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -17,6 +17,8 @@ use PhpCfdi\Finkok\Services\Stamping\StampingResult;
 use PhpCfdi\Finkok\Services\Stamping\StampService;
 use PhpCfdi\Finkok\Tests\Factories\RandomPreCfdi;
 use PhpCfdi\Finkok\Tests\TestCase;
+use PhpCfdi\XmlCancelacion\Models\CancelDocument;
+use PhpCfdi\XmlCancelacion\Models\CancelDocuments;
 use RuntimeException;
 
 abstract class IntegrationTestCase extends TestCase
@@ -77,12 +79,12 @@ abstract class IntegrationTestCase extends TestCase
         return GetSatStatusExtractor::fromXmlString($xmlContents)->buildCommand();
     }
 
-    protected function createCancelSignatureCommandFromUuid(
-        string $uuid,
+    protected function createCancelSignatureCommandFromDocument(
+        CancelDocument $document,
         ?DateTimeImmutable $dateTime = null
     ): CancelSignatureCommand {
         $credential = $this->createCsdCredential();
-        $signer = new CancelSigner([$uuid], $dateTime);
+        $signer = new CancelSigner(new CancelDocuments($document), $dateTime);
         return new CancelSignatureCommand($signer->sign($credential));
     }
 

--- a/tests/Integration/Services/Cancel/CancelServicesTest.php
+++ b/tests/Integration/Services/Cancel/CancelServicesTest.php
@@ -9,6 +9,7 @@ use PhpCfdi\Finkok\Services\Cancel\CancelSignatureService;
 use PhpCfdi\Finkok\Services\Cancel\GetReceiptCommand;
 use PhpCfdi\Finkok\Services\Cancel\GetReceiptService;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
+use PhpCfdi\XmlCancelacion\Models\CancelDocument;
 
 final class CancelServicesTest extends IntegrationTestCase
 {
@@ -38,7 +39,9 @@ final class CancelServicesTest extends IntegrationTestCase
         $repeatUntil = strtotime('now +5 minutes');
         do {
             // build command on every request
-            $command = $this->createCancelSignatureCommandFromUuid($cfdi->uuid());
+            $command = $this->createCancelSignatureCommandFromDocument(
+                CancelDocument::newWithErrorsUnrelated($cfdi->uuid())
+            );
             // perform cancel
             $result = $service->cancelSignature($command);
             $document = $result->documents()->first();

--- a/tests/Integration/Services/Cancel/CancelServicesTest.php
+++ b/tests/Integration/Services/Cancel/CancelServicesTest.php
@@ -57,8 +57,10 @@ final class CancelServicesTest extends IntegrationTestCase
             // 300: SAT authentication cancellation service fail
             // 305: SAT thinks "Certificado Inválido", it might be because incorrect time verification
             // 205: SAT does not have the uuid available for cancellation
-            if (! in_array($result->statusCode(), ['708', '300', '305'], true)
-                && '205' !== $document->documentStatus()) {
+            if (
+                ! in_array($result->statusCode(), ['708', '300', '305'], true)
+                && '205' !== $document->documentStatus()
+            ) {
                 break;
             }
             // do not try again if in the loop for more than allowed

--- a/tests/Integration/Services/Cancel/CancelSignatureServiceTest.php
+++ b/tests/Integration/Services/Cancel/CancelSignatureServiceTest.php
@@ -6,6 +6,7 @@ namespace PhpCfdi\Finkok\Tests\Integration\Services\Cancel;
 
 use PhpCfdi\Finkok\Services\Cancel\CancelSignatureService;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
+use PhpCfdi\XmlCancelacion\Models\CancelDocument;
 
 final class CancelSignatureServiceTest extends IntegrationTestCase
 {
@@ -17,7 +18,9 @@ final class CancelSignatureServiceTest extends IntegrationTestCase
 
     public function testCancelNonExistentUuid(): void
     {
-        $command = $this->createCancelSignatureCommandFromUuid('12345678-1234-1234-1234-123456789012');
+        $command = $this->createCancelSignatureCommandFromDocument(
+            CancelDocument::newWithErrorsUnrelated('12345678-1234-1234-1234-123456789012')
+        );
         $service = $this->createService();
         $result = $service->cancelSignature($command);
         $this->assertSame('UUID Not Found', $result->statusCode());

--- a/tests/Integration/Services/Cancel/GetRelatedSignatureServiceTest.php
+++ b/tests/Integration/Services/Cancel/GetRelatedSignatureServiceTest.php
@@ -72,9 +72,11 @@ final class GetRelatedSignatureServiceTest extends IntegrationTestCase
             // 2001 - No Existen cfdi relacionados al folio fiscal.
             // 305 - No se cuenta con un certificado válido.
             // Testing only: in the wild it is expected to ask for related several seconds after the CFDI were created
-            if ('' !== $result->error()
+            if (
+                '' !== $result->error()
                 && '2001' !== substr($result->error(), 0, 4)
-                && false === strpos($result->error(), '305')) {
+                && false === strpos($result->error(), '305')
+            ) {
                 break;
             }
 

--- a/tests/Integration/Services/Manifest/GetDocumentsSignSendAndGetSignedTest.php
+++ b/tests/Integration/Services/Manifest/GetDocumentsSignSendAndGetSignedTest.php
@@ -25,7 +25,7 @@ final class GetDocumentsSignSendAndGetSignedTest extends IntegrationTestCase
         $fiel = $this->createFielCredential();
         $address = 'Cuauhtémoc #123, Colonia Centro, Villahermosa, Tabasco. CP 86000';
         $email = 'legal@empresa-conocida.mx';
-        $snid = strval(getenv('FINKOK_SNID') ?? '');
+        $snid = strval(getenv('FINKOK_SNID') ?: '');
 
         $signedContracts = $finkok->customerSignAndSendContracts($fiel, $snid, $address, $email);
         $this->assertTrue($signedContracts->success());

--- a/tests/Integration/Services/Manifest/GetDocumentsSignSendAndGetSignedTest.php
+++ b/tests/Integration/Services/Manifest/GetDocumentsSignSendAndGetSignedTest.php
@@ -25,7 +25,7 @@ final class GetDocumentsSignSendAndGetSignedTest extends IntegrationTestCase
         $fiel = $this->createFielCredential();
         $address = 'Cuauhtémoc #123, Colonia Centro, Villahermosa, Tabasco. CP 86000';
         $email = 'legal@empresa-conocida.mx';
-        $snid = strval(getenv('FINKOK_SNID') ?: '');
+        $snid = $this->getenv('FINKOK_SNID');
 
         $signedContracts = $finkok->customerSignAndSendContracts($fiel, $snid, $address, $email);
         $this->assertTrue($signedContracts->success());

--- a/tests/Integration/Services/Manifest/GetSignedContractsServiceTest.php
+++ b/tests/Integration/Services/Manifest/GetSignedContractsServiceTest.php
@@ -34,7 +34,7 @@ final class GetSignedContractsServiceTest extends IntegrationTestCase
     public function testGetSignedContracts(SignedDocumentFormat $format, string $expectedMimeType): void
     {
         $command = new GetSignedContractsCommand(
-            strval(getenv('FINKOK_SNID') ?: ''),
+            $this->getenv('FINKOK_SNID'),
             'EKU9003173C9',
             $format
         );

--- a/tests/Integration/Services/Manifest/GetSignedContractsServiceTest.php
+++ b/tests/Integration/Services/Manifest/GetSignedContractsServiceTest.php
@@ -34,7 +34,7 @@ final class GetSignedContractsServiceTest extends IntegrationTestCase
     public function testGetSignedContracts(SignedDocumentFormat $format, string $expectedMimeType): void
     {
         $command = new GetSignedContractsCommand(
-            strval(getenv('FINKOK_SNID') ?? ''),
+            strval(getenv('FINKOK_SNID') ?: ''),
             'EKU9003173C9',
             $format
         );

--- a/tests/Integration/Services/Manifest/SignContractsServiceTest.php
+++ b/tests/Integration/Services/Manifest/SignContractsServiceTest.php
@@ -41,7 +41,7 @@ final class SignContractsServiceTest extends IntegrationTestCase
         $contractDocument = new DocumentSigner($rfc, $signDate, $contract);
 
         $cmdSignContracts = new SignContractsCommand(
-            strval(getenv('FINKOK_SNID') ?: ''),
+            $this->getenv('FINKOK_SNID'),
             $privacyDocument->sign($certificateFile, $privateKeyFile, $passPhrase),
             $contractDocument->sign($certificateFile, $privateKeyFile, $passPhrase)
         );

--- a/tests/Integration/Services/Manifest/SignContractsServiceTest.php
+++ b/tests/Integration/Services/Manifest/SignContractsServiceTest.php
@@ -41,7 +41,7 @@ final class SignContractsServiceTest extends IntegrationTestCase
         $contractDocument = new DocumentSigner($rfc, $signDate, $contract);
 
         $cmdSignContracts = new SignContractsCommand(
-            strval(getenv('FINKOK_SNID') ?? ''),
+            strval(getenv('FINKOK_SNID') ?: ''),
             $privacyDocument->sign($certificateFile, $privateKeyFile, $passPhrase),
             $contractDocument->sign($certificateFile, $privateKeyFile, $passPhrase)
         );

--- a/tests/Integration/Services/Registration/AddServiceTest.php
+++ b/tests/Integration/Services/Registration/AddServiceTest.php
@@ -45,7 +45,7 @@ final class AddServiceTest extends RegistrationIntegrationTestCase
     {
         // Finkok does not have a method (automated or manual) to remove customers.
         // This is why this test is always skipped.
-        // To remove any RFC send an email to soporte@finkok.com asking for it.
+        // To remove any RFC email soporte@finkok.com asking for it.
 
         // If you really need to test comment the following lines .
         if (! boolval(getenv('FINKOK_REGISTRATION_ADD_CREATE_RANDOM_RFC') ?: 0)) {

--- a/tests/Integration/Services/Registration/AddServiceTest.php
+++ b/tests/Integration/Services/Registration/AddServiceTest.php
@@ -48,7 +48,7 @@ final class AddServiceTest extends RegistrationIntegrationTestCase
         // To remove any RFC email soporte@finkok.com asking for it.
 
         // If you really need to test comment the following lines .
-        if (! boolval(getenv('FINKOK_REGISTRATION_ADD_CREATE_RANDOM_RFC') ?: 0)) {
+        if (! $this->getenv('FINKOK_REGISTRATION_ADD_CREATE_RANDOM_RFC')) {
             $this->markTestSkipped('This test is skipped as will create a lot of garbage customers');
         }
 

--- a/tests/Integration/Services/Retentions/CancelSignatureServiceTest.php
+++ b/tests/Integration/Services/Retentions/CancelSignatureServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpCfdi\Finkok\Tests\Integration\Services\Retentions;
 
 use PhpCfdi\Finkok\QuickFinkok;
+use PhpCfdi\XmlCancelacion\Models\CancelDocument;
 use RuntimeException;
 
 /**
@@ -24,7 +25,10 @@ final class CancelSignatureServiceTest extends RetentionsTestCase
     public function testCancelSignatureWithNonExistentUUID(): void
     {
         $uuid = '11111111-2222-3333-4444-000000000001';
-        $result = $this->quickFinkok->retentionCancel($this->createCsdCredential(), $uuid);
+        $result = $this->quickFinkok->retentionCancel(
+            $this->createCsdCredential(),
+            CancelDocument::newWithErrorsUnrelated($uuid)
+        );
         $this->assertSame('UUID Not Found', $result->statusCode());
     }
 
@@ -39,7 +43,10 @@ final class CancelSignatureServiceTest extends RetentionsTestCase
 
         $maxtime = strtotime('+5 minutes');
         while (true) {
-            $result = $this->quickFinkok->retentionCancel($this->createCsdCredential(), $uuid);
+            $result = $this->quickFinkok->retentionCancel(
+                $this->createCsdCredential(),
+                CancelDocument::newWithErrorsUnrelated($uuid)
+            );
             $document = $result->documents()->first();
 
             // do not try again if a SAT issue is **not** found

--- a/tests/Integration/Services/Stamping/QuickStampServiceTest.php
+++ b/tests/Integration/Services/Stamping/QuickStampServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpCfdi\Finkok\Tests\Integration\Services\Stamping;
 
 use PhpCfdi\Finkok\Services\Stamping\QuickStampService;
+use PhpCfdi\Finkok\Services\Stamping\StampingCommand;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
 final class QuickStampServiceTest extends IntegrationTestCase
@@ -37,6 +38,20 @@ final class QuickStampServiceTest extends IntegrationTestCase
         $this->assertNotNull(
             $secondResult->alerts()->findByErrorCode('307'),
             'Finkok must alert that it was previously stamped'
+        );
+    }
+
+    public function testQuickStampPreviouslyCreatedCfdiReturnsErrorCode707(): void
+    {
+        // call first to cachedStamped to use previous stamp or create a new one
+        $this->currentCfdi();
+
+        $service = $this->createService();
+        $currentCfdiStampCommand = new StampingCommand($this->currentCfdi()->xml());
+        $secondResult = $service->quickstamp($currentCfdiStampCommand);
+        $this->assertNotNull(
+            $secondResult->alerts()->findByErrorCode('707'),
+            'Finkok must alert that it contains and existing TFD'
         );
     }
 

--- a/tests/Integration/Services/Stamping/StampServiceTest.php
+++ b/tests/Integration/Services/Stamping/StampServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\Finkok\Tests\Integration\Services\Stamping;
 
+use PhpCfdi\Finkok\Services\Stamping\StampingCommand;
 use PhpCfdi\Finkok\Services\Stamping\StampService;
 use PhpCfdi\Finkok\Tests\Integration\IntegrationTestCase;
 
@@ -27,7 +28,7 @@ final class StampServiceTest extends IntegrationTestCase
         $this->assertStringContainsString($result->uuid(), $result->xml());
     }
 
-    public function testStampPreviouslyCreatedCfdi(): void
+    public function testStampPreviouslyCreatedCfdiReturnsErrorCode307(): void
     {
         $firstResult = $this->currentCfdi();
 
@@ -41,6 +42,20 @@ final class StampServiceTest extends IntegrationTestCase
             $firstResult->uuid(),
             $secondResult->uuid(),
             'Finkok does not return the same UUID for duplicated stamp call'
+        );
+    }
+
+    public function testStampPreviouslyCreatedCfdiReturnsErrorCode707(): void
+    {
+        // call first to cachedStamped to use previous stamp or create a new one
+        $this->currentCfdi();
+
+        $service = $this->createService();
+        $currentCfdiStampCommand = new StampingCommand($this->currentCfdi()->xml());
+        $secondResult = $service->stamp($currentCfdiStampCommand);
+        $this->assertNotNull(
+            $secondResult->alerts()->findByErrorCode('707'),
+            'Finkok must alert that it contains and existing TFD'
         );
     }
 

--- a/tests/Integration/Services/Utilities/DownloadXmlServiceTest.php
+++ b/tests/Integration/Services/Utilities/DownloadXmlServiceTest.php
@@ -25,7 +25,7 @@ final class DownloadXmlServiceTest extends IntegrationTestCase
         $this->assertSame('UUID Does not Exists', $result->error());
     }
 
-    public function testStampAndConsumeStampedImmediately(): void
+    public function testStampAndDownloadXmlImmediately(): void
     {
         $previousStamp = $this->currentCfdi();
         $this->assertNotEmpty($previousStamp->uuid(), 'Finkok did not create CFDI');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,15 +15,15 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     public function createSettingsFromEnvironment(SoapFactory $soapFactory = null): FinkokSettings
     {
         $settings = new FinkokSettings(
-            strval(getenv('FINKOK_USERNAME')) ?: 'username-non-set',
-            strval(getenv('FINKOK_PASSWORD')) ?: 'password-non-set',
+            $this->getenv('FINKOK_USERNAME') ?: 'username-non-set',
+            $this->getenv('FINKOK_PASSWORD') ?: 'password-non-set',
             FinkokEnvironment::makeDevelopment()
         );
         if (null !== $soapFactory) {
             $settings->changeSoapFactory($soapFactory);
         }
 
-        if (boolval(getenv('FINKOK_LOG_CALLS'))) {
+        if ($this->getenv('FINKOK_LOG_CALLS')) {
             $loggerOutputFile = sprintf(
                 '%s/../build/tests/%s-%s-%s.txt',
                 __DIR__,
@@ -68,5 +68,10 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
             return '';
         }
         return strval(file_get_contents($path));
+    }
+
+    public static function getenv(string $key): string
+    {
+        return $_ENV[$key] ?? '';
     }
 }

--- a/tests/Unit/FinkokTest.php
+++ b/tests/Unit/FinkokTest.php
@@ -83,7 +83,7 @@ final class FinkokTest extends TestCase
     {
         /** @var FinkokSettings&MockObject $settings */
         $settings = $this->createMock(FinkokSettings::class);
-        $finkok = new class($settings) extends Finkok {
+        $finkok = new class ($settings) extends Finkok {
             /**
              * created just to access protected method
              *
@@ -136,7 +136,7 @@ final class FinkokTest extends TestCase
     {
         /** @var FinkokSettings&MockObject $settings */
         $settings = $this->createMock(FinkokSettings::class);
-        $exposer = new class($settings) extends Finkok {
+        $exposer = new class ($settings) extends Finkok {
             /** @return array<array<mixed>> */
             public function exposeServicesMap(): array
             {

--- a/tests/Unit/Helpers/AcceptRejectSignerTest.php
+++ b/tests/Unit/Helpers/AcceptRejectSignerTest.php
@@ -7,7 +7,6 @@ namespace PhpCfdi\Finkok\Tests\Unit\Helpers;
 use DateTimeImmutable;
 use PhpCfdi\Finkok\Definitions\CancelAnswer;
 use PhpCfdi\Finkok\Helpers\AcceptRejectSigner;
-
 use PhpCfdi\Finkok\Tests\TestCase;
 
 final class AcceptRejectSignerTest extends TestCase

--- a/tests/Unit/Helpers/CancelSignerTest.php
+++ b/tests/Unit/Helpers/CancelSignerTest.php
@@ -6,7 +6,6 @@ namespace PhpCfdi\Finkok\Tests\Unit\Helpers;
 
 use DateTimeImmutable;
 use PhpCfdi\Finkok\Helpers\CancelSigner;
-
 use PhpCfdi\Finkok\Tests\TestCase;
 use PhpCfdi\XmlCancelacion\Models\CancelDocument;
 use PhpCfdi\XmlCancelacion\Models\CancelDocuments;

--- a/tests/Unit/Helpers/CancelSignerTest.php
+++ b/tests/Unit/Helpers/CancelSignerTest.php
@@ -8,19 +8,20 @@ use DateTimeImmutable;
 use PhpCfdi\Finkok\Helpers\CancelSigner;
 
 use PhpCfdi\Finkok\Tests\TestCase;
+use PhpCfdi\XmlCancelacion\Models\CancelDocument;
+use PhpCfdi\XmlCancelacion\Models\CancelDocuments;
 
 final class CancelSignerTest extends TestCase
 {
     public function testCreateAndSign(): void
     {
-        $uuids = [
-            '4CE93193-9E57-4BB0-9E03-09BAB53D392E',
-            '4CE93193-9E57-4BB0-9E03-F896B148A146',
-        ];
-        $date = new DateTimeImmutable('2019-01-13 14:15:16');
+        $documents = new CancelDocuments(
+            CancelDocument::newWithErrorsUnrelated('62B00C5E-4187-4336-B569-44E0030DC729'),
+        );
+        $date = new DateTimeImmutable('2022-01-06 17:49:12');
 
-        $signer = new CancelSigner($uuids, $date);
-        $this->assertSame($uuids, $signer->uuids());
+        $signer = new CancelSigner($documents, $date);
+        $this->assertSame($documents, $signer->documents());
         $this->assertSame($date, $signer->dateTime());
 
         $signed = $signer->sign($this->createCsdCredential());

--- a/tests/Unit/Helpers/DocumentSignerTest.php
+++ b/tests/Unit/Helpers/DocumentSignerTest.php
@@ -9,7 +9,6 @@ use DOMDocument;
 use LogicException;
 use PhpCfdi\Credentials\Credential;
 use PhpCfdi\Finkok\Helpers\DocumentSigner;
-
 use PhpCfdi\Finkok\Tests\TestCase;
 
 final class DocumentSignerTest extends TestCase

--- a/tests/Unit/Helpers/GetRelatedSignerTest.php
+++ b/tests/Unit/Helpers/GetRelatedSignerTest.php
@@ -6,7 +6,6 @@ namespace PhpCfdi\Finkok\Tests\Unit\Helpers;
 
 use PhpCfdi\Finkok\Definitions\RfcRole;
 use PhpCfdi\Finkok\Helpers\GetRelatedSigner;
-
 use PhpCfdi\Finkok\Tests\TestCase;
 
 final class GetRelatedSignerTest extends TestCase

--- a/tests/Unit/Helpers/GetSatStatusExtractorTest.php
+++ b/tests/Unit/Helpers/GetSatStatusExtractorTest.php
@@ -23,17 +23,17 @@ final class GetSatStatusExtractorTest extends TestCase
     public function testConstructWithFakeCfdi33(): void
     {
         $fakeCfdi = <<<EOT
-<cfdi:Comprobante xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xmlns:cfdi="http://www.sat.gob.mx/cfd/3"
-                  xmlns:tfd="http://www.sat.gob.mx/TimbreFiscalDigital"
-                  Version="3.3" Total="123.45" Sello="">
-    <cfdi:Emisor Rfc="EKU9003173C9"/>
-    <cfdi:Receptor Rfc="COSC8001137NA"/>
-    <cfdi:Complemento>
-        <tfd:TimbreFiscalDigital UUID="12345678-1234-1234-1234-000000000001"/>
-    </cfdi:Complemento>
-</cfdi:Comprobante>
-EOT;
+            <cfdi:Comprobante xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                              xmlns:cfdi="http://www.sat.gob.mx/cfd/3"
+                              xmlns:tfd="http://www.sat.gob.mx/TimbreFiscalDigital"
+                              Version="3.3" Total="123.45" Sello="">
+                <cfdi:Emisor Rfc="EKU9003173C9"/>
+                <cfdi:Receptor Rfc="COSC8001137NA"/>
+                <cfdi:Complemento>
+                    <tfd:TimbreFiscalDigital UUID="12345678-1234-1234-1234-000000000001"/>
+                </cfdi:Complemento>
+            </cfdi:Comprobante>
+            EOT;
         $extractor = GetSatStatusExtractor::fromXmlString($fakeCfdi);
         $command = $extractor->buildCommand();
         $this->assertSame('EKU9003173C9', $command->rfcIssuer());

--- a/tests/Unit/QuickFinkokTest.php
+++ b/tests/Unit/QuickFinkokTest.php
@@ -59,6 +59,7 @@ final class QuickFinkokTest extends TestCase
 
     public function testStamp(): void
     {
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('stamp-response-with-alerts.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
         $result = $finkok->stamp('precfdi');
@@ -68,6 +69,7 @@ final class QuickFinkokTest extends TestCase
 
     public function testQuickStamp(): void
     {
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('quickstamp-response-with-alerts.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
         $result = $finkok->quickStamp('precfdi');
@@ -77,6 +79,7 @@ final class QuickFinkokTest extends TestCase
 
     public function testStamped(): void
     {
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('stamped-response-with-alerts.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
         $result = $finkok->stamped('precfdi');
@@ -86,6 +89,7 @@ final class QuickFinkokTest extends TestCase
 
     public function testCfdiDownload(): void
     {
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('utilities-getxml-response.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
         $result = $finkok->cfdiDownload('x-uuid', 'x-rfc');
@@ -98,6 +102,7 @@ final class QuickFinkokTest extends TestCase
 
     public function testStampQueryPending(): void
     {
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('querypending-response.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
         $result = $finkok->stampQueryPending('x-uuid');
@@ -107,6 +112,7 @@ final class QuickFinkokTest extends TestCase
 
     public function testCancel(): void
     {
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('cancel-cancelsignature-response-2-items.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
         $uuid = '12345678-1234-aaaa-1234-1234567890ab';
@@ -120,6 +126,7 @@ final class QuickFinkokTest extends TestCase
 
     public function testSatStatus(): void
     {
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('cancel-get-sat-status-response.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
         $result = $finkok->satStatus('EKU9003173C9', 'COSC8001137NA', 'x-uuid', '123.45');
@@ -135,17 +142,18 @@ final class QuickFinkokTest extends TestCase
     public function testSatStatusXml(): void
     {
         $fakeCfdi = <<<EOT
-<cfdi:Comprobante xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xmlns:cfdi="http://www.sat.gob.mx/cfd/3"
-                  xmlns:tfd="http://www.sat.gob.mx/TimbreFiscalDigital"
-                  Version="3.3" Total="123.45" Sello="">
-    <cfdi:Emisor Rfc="EKU9003173C9"/>
-    <cfdi:Receptor Rfc="COSC8001137NA"/>
-    <cfdi:Complemento>
-        <tfd:TimbreFiscalDigital UUID="12345678-1234-1234-1234-000000000001"/>
-    </cfdi:Complemento>
-</cfdi:Comprobante>
-EOT;
+            <cfdi:Comprobante xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                              xmlns:cfdi="http://www.sat.gob.mx/cfd/3"
+                              xmlns:tfd="http://www.sat.gob.mx/TimbreFiscalDigital"
+                              Version="3.3" Total="123.45" Sello="">
+                <cfdi:Emisor Rfc="EKU9003173C9"/>
+                <cfdi:Receptor Rfc="COSC8001137NA"/>
+                <cfdi:Complemento>
+                    <tfd:TimbreFiscalDigital UUID="12345678-1234-1234-1234-000000000001"/>
+                </cfdi:Complemento>
+            </cfdi:Comprobante>
+            EOT;
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('cancel-get-sat-status-response.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
         $result = $finkok->satStatusXml($fakeCfdi);
@@ -160,6 +168,7 @@ EOT;
 
     public function testObtainRelated(): void
     {
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('cancel-get-related-signature-response.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
 
@@ -174,6 +183,7 @@ EOT;
 
     public function testObtainPendingToCancel(): void
     {
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('cancel-get-pending-response-2-items.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
         $result = $finkok->obtainPendingToCancel('EKU9003173C9');
@@ -183,6 +193,7 @@ EOT;
 
     public function testAnswerAcceptRejectCancellation(): void
     {
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('cancel-accept-reject-signature-response.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
 
@@ -202,6 +213,7 @@ EOT;
 
     public function testObtainCancelRequestReceipt(): void
     {
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('cancel-get-receipt-response.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
 
@@ -217,6 +229,7 @@ EOT;
 
     public function testServersDateTime(): void
     {
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('utilities-datetime-response.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
 
@@ -228,6 +241,7 @@ EOT;
 
     public function testReportUuids(): void
     {
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('utilities-report-uuid-response.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
 
@@ -246,6 +260,7 @@ EOT;
 
     public function testReportCredits(): void
     {
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('utilities-report-credit-response.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
 
@@ -257,6 +272,7 @@ EOT;
 
     public function testReportTotals(): void
     {
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('utilities-report-total-response.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
 
@@ -273,6 +289,7 @@ EOT;
 
     public function testCustomersAdd(): void
     {
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('registration-add-response.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
 
@@ -287,6 +304,7 @@ EOT;
 
     public function testCustomersEdit(): void
     {
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('registration-edit-response.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
 
@@ -301,6 +319,7 @@ EOT;
 
     public function testCustomersSwitch(): void
     {
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('registration-switch-response.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
 
@@ -316,6 +335,7 @@ EOT;
 
     public function testCustomersAssign(): void
     {
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('registration-assign-response.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
 
@@ -330,6 +350,7 @@ EOT;
 
     public function testCustomersObtain(): void
     {
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('registration-get-response-2-items.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
 
@@ -343,6 +364,7 @@ EOT;
 
     public function testCustomerGetContracts(): void
     {
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('manifest-getcontracts-response.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
 
@@ -359,6 +381,7 @@ EOT;
 
     public function testCustomerSendContracts(): void
     {
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('manifest-signcontracts-response.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
 
@@ -375,12 +398,12 @@ EOT;
     public function testCustomerSignAndSendContracts(): void
     {
         $fiel = $this->createCsdCredential();
-        $getContractsResult = new GetContractsResult(
-            json_decode($this->fileContentPath('manifest-getcontracts-response.json'))
-        );
-        $signContractsResult = new SignContractsResult(
-            json_decode($this->fileContentPath('manifest-signcontracts-response.json'))
-        );
+        /** @var stdClass $dataGetContracts */
+        $dataGetContracts = json_decode($this->fileContentPath('manifest-getcontracts-response.json'));
+        $getContractsResult = new GetContractsResult($dataGetContracts);
+        /** @var stdClass $dataSignContracts */
+        $dataSignContracts = json_decode($this->fileContentPath('manifest-signcontracts-response.json'));
+        $signContractsResult = new SignContractsResult($dataSignContracts);
         /** @var QuickFinkok&MockObject $finkok */
         $finkok = $this->getMockBuilder(QuickFinkok::class)
             ->disableOriginalConstructor()
@@ -423,6 +446,7 @@ EOT;
 
     public function testRetentionStamp(): void
     {
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('retentions-stamp-response.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
         $result = $finkok->retentionStamp('precfdi');
@@ -441,6 +465,7 @@ EOT;
 
     public function testRetentionStamped(): void
     {
+        /** @var stdClass $rawData */
         $rawData = json_decode($this->fileContentPath('retentions-stamped-response.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
         $result = $finkok->retentionStamped('x-xml');

--- a/tests/Unit/QuickFinkokTest.php
+++ b/tests/Unit/QuickFinkokTest.php
@@ -14,6 +14,7 @@ use PhpCfdi\Finkok\Services\Registration\CustomerStatus;
 use PhpCfdi\Finkok\Services\Registration\CustomerType;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use PhpCfdi\XmlCancelacion\Models\CancelDocument;
 use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
 
@@ -108,11 +109,12 @@ final class QuickFinkokTest extends TestCase
     {
         $rawData = json_decode($this->fileContentPath('cancel-cancelsignature-response-2-items.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
-        $result = $finkok->cancel($this->createCsdCredential(), 'x-uuid');
+        $uuid = '12345678-1234-aaaa-1234-1234567890ab';
+        $result = $finkok->cancel($this->createCsdCredential(), CancelDocument::newWithErrorsUnrelated($uuid));
         $this->performTestOnLatestCall('cancel_signature', [
             'store_pending' => false,
         ]);
-        $this->assertStringContainsString('X-UUID', strval($this->obtainParameterFromLatestCall('xml')));
+        $this->assertStringContainsString(strtoupper($uuid), strval($this->obtainParameterFromLatestCall('xml')));
         $this->assertEquals($rawData, $result->rawData());
     }
 

--- a/tests/Unit/Services/Cancel/AcceptRejectSignatureResultTest.php
+++ b/tests/Unit/Services/Cancel/AcceptRejectSignatureResultTest.php
@@ -6,11 +6,13 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Cancel;
 
 use PhpCfdi\Finkok\Services\Cancel\AcceptRejectSignatureResult;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class AcceptRejectSignatureResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponse(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('cancel-accept-reject-signature-response.json'));
         $result = new AcceptRejectSignatureResult($data);
 

--- a/tests/Unit/Services/Cancel/AcceptRejectSignatureServiceTest.php
+++ b/tests/Unit/Services/Cancel/AcceptRejectSignatureServiceTest.php
@@ -8,11 +8,13 @@ use PhpCfdi\Finkok\Services\Cancel\AcceptRejectSignatureCommand;
 use PhpCfdi\Finkok\Services\Cancel\AcceptRejectSignatureService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class AcceptRejectSignatureServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('cancel-accept-reject-signature-response.json'));
         $soapFactory = new FakeSoapFactory();
         $soapFactory->preparedResult = $preparedResult;

--- a/tests/Unit/Services/Cancel/AcceptRejectUuidListTest.php
+++ b/tests/Unit/Services/Cancel/AcceptRejectUuidListTest.php
@@ -17,11 +17,11 @@ final class AcceptRejectUuidListTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $source = json_decode(json_encode([
-            ['Rechaza' => ['uuid' => '12345678-AAAA-1234-1234-000000000001', 'status' => '1000']],
-            ['Rechaza' => ['uuid' => '12345678-AAAA-1234-1234-000000000002', 'status' => '1001']],
-            ['Acepta' => ['uuid' => '12345678-AAAA-1234-1234-000000000003', 'status' => '1000']],
-        ]) ?: '');
+        $source = [
+            (object) ['Rechaza' => (object) ['uuid' => '12345678-AAAA-1234-1234-000000000001', 'status' => '1000']],
+            (object) ['Rechaza' => (object) ['uuid' => '12345678-AAAA-1234-1234-000000000002', 'status' => '1001']],
+            (object) ['Acepta' => (object) ['uuid' => '12345678-AAAA-1234-1234-000000000003', 'status' => '1000']],
+        ];
         $this->list = new AcceptRejectUuidList($source);
     }
 
@@ -75,11 +75,11 @@ final class AcceptRejectUuidListTest extends TestCase
 
     public function testConstructUsingInvalidSource(): void
     {
-        $source = json_decode(json_encode([
-            ['Foo' => ['uuid' => '12345678-AAAA-1234-1234-000000000000', 'status' => '1001']],
-            ['Rechaza' => ['status' => '1000']],
-            ['Acepta' => ['uuid' => '12345678-AAAA-1234-1234-000000000002']],
-        ]) ?: '');
+        $source = [
+            (object) ['Foo' => (object) ['uuid' => '12345678-AAAA-1234-1234-000000000000', 'status' => '1001']],
+            (object) ['Rechaza' => (object) ['status' => '1000']],
+            (object) ['Acepta' => (object) ['uuid' => '12345678-AAAA-1234-1234-000000000002']],
+        ];
         $list = new AcceptRejectUuidList($source);
 
         $this->assertCount(3, $list);

--- a/tests/Unit/Services/Cancel/CancelSignatureResultTest.php
+++ b/tests/Unit/Services/Cancel/CancelSignatureResultTest.php
@@ -6,11 +6,13 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Cancel;
 
 use PhpCfdi\Finkok\Services\Cancel\CancelSignatureResult;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class CancelSignatureResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponses(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('cancel-cancelsignature-response-2-items.json'));
         $result = new CancelSignatureResult($data);
         $this->assertCount(2, $result->documents());

--- a/tests/Unit/Services/Cancel/CancelSignatureServiceTest.php
+++ b/tests/Unit/Services/Cancel/CancelSignatureServiceTest.php
@@ -9,11 +9,13 @@ use PhpCfdi\Finkok\Services\Cancel\CancelSignatureCommand;
 use PhpCfdi\Finkok\Services\Cancel\CancelSignatureService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class CancelSignatureServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('cancel-cancelsignature-response-2-items.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/Unit/Services/Cancel/CancelledDocumentTest.php
+++ b/tests/Unit/Services/Cancel/CancelledDocumentTest.php
@@ -28,29 +28,4 @@ final class CancelledDocumentTest extends TestCase
         $this->assertSame('foo bar', $folio->cancellationStatus());
         $this->assertSame($data, $folio->values());
     }
-
-    public function testMethodCancellationSatatusIsDeprecated(): void
-    {
-        $data = [
-            'UUID' => '728147B1-D5B9-4FDD-AEA9-526AEA2E6698',
-            'EstatusUUID' => '708',
-            'EstatusCancelacion' => 'foo bar',
-        ];
-        $document = new CancelledDocument((object) $data);
-        $this->expectDeprecation();
-        $document->cancellationSatatus();
-    }
-
-    public function testMethodCancellationSatatusReturnExpectedValue(): void
-    {
-        $data = [
-            'UUID' => '728147B1-D5B9-4FDD-AEA9-526AEA2E6698',
-            'EstatusUUID' => '708',
-            'EstatusCancelacion' => 'foo bar',
-        ];
-        $document = new CancelledDocument((object) $data);
-        /** @noinspection PhpUsageOfSilenceOperatorInspection */
-        $retrieved = @$document->cancellationSatatus();
-        $this->assertSame($document->cancellationStatus(), $retrieved);
-    }
 }

--- a/tests/Unit/Services/Cancel/GetPendingResultTest.php
+++ b/tests/Unit/Services/Cancel/GetPendingResultTest.php
@@ -6,11 +6,13 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Cancel;
 
 use PhpCfdi\Finkok\Services\Cancel\GetPendingResult;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class GetPendingResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponse(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('cancel-get-pending-response-2-items.json'));
         $result = new GetPendingResult($data);
         $this->assertSame([
@@ -22,6 +24,7 @@ final class GetPendingResultTest extends TestCase
 
     public function testResultUsingEmptyList(): void
     {
+        /** @var stdClass $data */
         $data = json_decode('{"get_pendingResult": {}}');
         $result = new GetPendingResult($data);
         $this->assertSame([], $result->uuids());

--- a/tests/Unit/Services/Cancel/GetPendingServiceTest.php
+++ b/tests/Unit/Services/Cancel/GetPendingServiceTest.php
@@ -8,11 +8,13 @@ use PhpCfdi\Finkok\Services\Cancel\GetPendingCommand;
 use PhpCfdi\Finkok\Services\Cancel\GetPendingService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class GetPendingServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('cancel-get-pending-response-2-items.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/Unit/Services/Cancel/GetReceiptResultTest.php
+++ b/tests/Unit/Services/Cancel/GetReceiptResultTest.php
@@ -6,11 +6,13 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Cancel;
 
 use PhpCfdi\Finkok\Services\Cancel\GetReceiptResult;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class GetReceiptResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponse(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('cancel-get-receipt-response.json'));
         $result = new GetReceiptResult($data);
         $this->assertTrue($result->isSuccess());

--- a/tests/Unit/Services/Cancel/GetReceiptServiceTest.php
+++ b/tests/Unit/Services/Cancel/GetReceiptServiceTest.php
@@ -9,11 +9,13 @@ use PhpCfdi\Finkok\Services\Cancel\GetReceiptCommand;
 use PhpCfdi\Finkok\Services\Cancel\GetReceiptService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class GetReceiptServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('cancel-get-receipt-response.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/Unit/Services/Cancel/GetRelatedSignatureResultTest.php
+++ b/tests/Unit/Services/Cancel/GetRelatedSignatureResultTest.php
@@ -6,11 +6,13 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Cancel;
 
 use PhpCfdi\Finkok\Services\Cancel\GetRelatedSignatureResult;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class GetRelatedSignatureResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponse(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('cancel-get-related-signature-response.json'));
         $result = new GetRelatedSignatureResult($data);
         $parents = $result->parents();

--- a/tests/Unit/Services/Cancel/GetRelatedSignatureServiceTest.php
+++ b/tests/Unit/Services/Cancel/GetRelatedSignatureServiceTest.php
@@ -8,11 +8,13 @@ use PhpCfdi\Finkok\Services\Cancel\GetRelatedSignatureCommand;
 use PhpCfdi\Finkok\Services\Cancel\GetRelatedSignatureService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class GetRelatedSignatureServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('cancel-get-related-signature-response.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/Unit/Services/Cancel/GetSatStatusResultTest.php
+++ b/tests/Unit/Services/Cancel/GetSatStatusResultTest.php
@@ -6,11 +6,13 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Cancel;
 
 use PhpCfdi\Finkok\Services\Cancel\GetSatStatusResult;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class GetSatStatusResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponse(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('cancel-get-sat-status-response.json'));
         $result = new GetSatStatusResult($data);
         $this->assertSame('S - Comprobante obtenido satisfactoriamente.', $result->query());

--- a/tests/Unit/Services/Cancel/GetSatStatusServiceTest.php
+++ b/tests/Unit/Services/Cancel/GetSatStatusServiceTest.php
@@ -8,11 +8,13 @@ use PhpCfdi\Finkok\Services\Cancel\GetSatStatusCommand;
 use PhpCfdi\Finkok\Services\Cancel\GetSatStatusService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class GetSatStatusServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('cancel-get-sat-status-response.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/Unit/Services/Manifest/GetContractsResultTest.php
+++ b/tests/Unit/Services/Manifest/GetContractsResultTest.php
@@ -6,11 +6,13 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Manifest;
 
 use PhpCfdi\Finkok\Services\Manifest\GetContractsResult;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class GetContractsResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponses(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('manifest-getcontracts-response.json'));
         $result = new GetContractsResult($data);
         $this->assertTrue($result->success());

--- a/tests/Unit/Services/Manifest/GetContractsServiceTest.php
+++ b/tests/Unit/Services/Manifest/GetContractsServiceTest.php
@@ -8,11 +8,13 @@ use PhpCfdi\Finkok\Services\Manifest\GetContractsCommand;
 use PhpCfdi\Finkok\Services\Manifest\GetContractsService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class GetContractsServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('manifest-getcontracts-response.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/Unit/Services/Manifest/GetSignedContractsResultTest.php
+++ b/tests/Unit/Services/Manifest/GetSignedContractsResultTest.php
@@ -6,11 +6,13 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Manifest;
 
 use PhpCfdi\Finkok\Services\Manifest\GetSignedContractsResult;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class GetSignedContractsResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponses(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('manifest-getsignedcontracts-response.json'));
         $result = new GetSignedContractsResult($data, false);
         $this->assertTrue($result->success());

--- a/tests/Unit/Services/Manifest/GetSignedContractsServiceTest.php
+++ b/tests/Unit/Services/Manifest/GetSignedContractsServiceTest.php
@@ -9,11 +9,13 @@ use PhpCfdi\Finkok\Services\Manifest\GetSignedContractsCommand;
 use PhpCfdi\Finkok\Services\Manifest\GetSignedContractsService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class GetSignedContractsServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('manifest-getsignedcontracts-response.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/Unit/Services/Manifest/SignContractsResultTest.php
+++ b/tests/Unit/Services/Manifest/SignContractsResultTest.php
@@ -6,11 +6,13 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Manifest;
 
 use PhpCfdi\Finkok\Services\Manifest\SignContractsResult;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class SignContractsResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponses(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('manifest-signcontracts-response.json'));
         $result = new SignContractsResult($data);
         $this->assertTrue($result->success());

--- a/tests/Unit/Services/Manifest/SignContractsServiceTest.php
+++ b/tests/Unit/Services/Manifest/SignContractsServiceTest.php
@@ -8,11 +8,13 @@ use PhpCfdi\Finkok\Services\Manifest\SignContractsCommand;
 use PhpCfdi\Finkok\Services\Manifest\SignContractsService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class SignContractsServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('manifest-signcontracts-response.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/Unit/Services/Registration/AddResultTest.php
+++ b/tests/Unit/Services/Registration/AddResultTest.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace PhpCfdi\Finkok\Tests\Unit\Services\Registration;
 
 use PhpCfdi\Finkok\Services\Registration\AddResult;
-
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class AddResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponses(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('registration-add-response.json'));
         $result = new AddResult($data);
         $this->assertSame(true, $result->success());

--- a/tests/Unit/Services/Registration/AddServiceTest.php
+++ b/tests/Unit/Services/Registration/AddServiceTest.php
@@ -9,11 +9,13 @@ use PhpCfdi\Finkok\Services\Registration\AddService;
 use PhpCfdi\Finkok\Services\Registration\CustomerType;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class AddServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('registration-add-response.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/Unit/Services/Registration/AssignResultTest.php
+++ b/tests/Unit/Services/Registration/AssignResultTest.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace PhpCfdi\Finkok\Tests\Unit\Services\Registration;
 
 use PhpCfdi\Finkok\Services\Registration\AssignResult;
-
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class AssignResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponses(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('registration-assign-response.json'));
         $result = new AssignResult($data);
         $this->assertSame(true, $result->success());

--- a/tests/Unit/Services/Registration/AssignServiceTest.php
+++ b/tests/Unit/Services/Registration/AssignServiceTest.php
@@ -8,11 +8,13 @@ use PhpCfdi\Finkok\Services\Registration\AssignCommand;
 use PhpCfdi\Finkok\Services\Registration\AssignService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class AssignServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('registration-assign-response.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/Unit/Services/Registration/CustomersTest.php
+++ b/tests/Unit/Services/Registration/CustomersTest.php
@@ -7,6 +7,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Registration;
 use LogicException;
 use PhpCfdi\Finkok\Services\Registration\Customers;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class CustomersTest extends TestCase
 {
@@ -18,6 +19,7 @@ final class CustomersTest extends TestCase
 
     public function testFindByRfc(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('registration-get-response-2-items.json'));
         $customers = new Customers($data->getResult->users->ResellerUser);
         $known = $customers->findByRfc('LAN7008173R5');
@@ -31,6 +33,7 @@ final class CustomersTest extends TestCase
     public function testGetByRfcUsingExistentRfc(): void
     {
         $expectedRfc = 'LAN7008173R5';
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('registration-get-response-2-items.json'));
         $customers = new Customers($data->getResult->users->ResellerUser);
         $this->assertSame($expectedRfc, $customers->getByRfc($expectedRfc)->rfc());
@@ -38,6 +41,7 @@ final class CustomersTest extends TestCase
 
     public function testGetByRfcUsingNonExistentRfcThrowsException(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('registration-get-response-2-items.json'));
         $customers = new Customers($data->getResult->users->ResellerUser);
 

--- a/tests/Unit/Services/Registration/EditResultTest.php
+++ b/tests/Unit/Services/Registration/EditResultTest.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace PhpCfdi\Finkok\Tests\Unit\Services\Registration;
 
 use PhpCfdi\Finkok\Services\Registration\EditResult;
-
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class EditResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponses(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('registration-edit-response.json'));
         $result = new EditResult($data);
         $this->assertSame(true, $result->success());

--- a/tests/Unit/Services/Registration/EditServiceTest.php
+++ b/tests/Unit/Services/Registration/EditServiceTest.php
@@ -9,11 +9,13 @@ use PhpCfdi\Finkok\Services\Registration\EditCommand;
 use PhpCfdi\Finkok\Services\Registration\EditService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class EditServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('registration-edit-response.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/Unit/Services/Registration/ObtainResultTest.php
+++ b/tests/Unit/Services/Registration/ObtainResultTest.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace PhpCfdi\Finkok\Tests\Unit\Services\Registration;
 
 use PhpCfdi\Finkok\Services\Registration\ObtainResult;
-
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class ObtainResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponses(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('registration-get-response-2-items.json'));
         $result = new ObtainResult($data);
         $this->assertSame('predefined-message', $result->message());

--- a/tests/Unit/Services/Registration/ObtainServiceTest.php
+++ b/tests/Unit/Services/Registration/ObtainServiceTest.php
@@ -8,11 +8,13 @@ use PhpCfdi\Finkok\Services\Registration\ObtainCommand;
 use PhpCfdi\Finkok\Services\Registration\ObtainService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class ObtainServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResultWithRfc(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('registration-get-response-2-items.json'));
 
         $soapFactory = new FakeSoapFactory();
@@ -35,6 +37,7 @@ final class ObtainServiceTest extends TestCase
 
     public function testServiceUsingPreparedResultWithoutRfc(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('registration-get-response-2-items.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/Unit/Services/Registration/SwitchResultTest.php
+++ b/tests/Unit/Services/Registration/SwitchResultTest.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace PhpCfdi\Finkok\Tests\Unit\Services\Registration;
 
 use PhpCfdi\Finkok\Services\Registration\SwitchResult;
-
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class SwitchResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponses(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('registration-switch-response.json'));
         $result = new SwitchResult($data);
         $this->assertSame(true, $result->success());

--- a/tests/Unit/Services/Registration/SwitchServiceTest.php
+++ b/tests/Unit/Services/Registration/SwitchServiceTest.php
@@ -9,11 +9,13 @@ use PhpCfdi\Finkok\Services\Registration\SwitchCommand;
 use PhpCfdi\Finkok\Services\Registration\SwitchService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class SwitchServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('registration-switch-response.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/Unit/Services/Retentions/CancelSignatureResultTest.php
+++ b/tests/Unit/Services/Retentions/CancelSignatureResultTest.php
@@ -6,11 +6,13 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Retentions;
 
 use PhpCfdi\Finkok\Services\Retentions\CancelSignatureResult;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class CancelSignatureResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponses(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('retentions-cancelsignature-response.json'));
         $result = new CancelSignatureResult($data);
         $this->assertCount(2, $result->documents());

--- a/tests/Unit/Services/Retentions/CancelSignatureServiceTest.php
+++ b/tests/Unit/Services/Retentions/CancelSignatureServiceTest.php
@@ -10,11 +10,13 @@ use PhpCfdi\Finkok\Services\Retentions\CancelSignatureCommand;
 use PhpCfdi\Finkok\Services\Retentions\CancelSignatureService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class CancelSignatureServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('retentions-cancelsignature-response.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/Unit/Services/Retentions/StampResultTest.php
+++ b/tests/Unit/Services/Retentions/StampResultTest.php
@@ -6,11 +6,13 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Retentions;
 
 use PhpCfdi\Finkok\Services\Retentions\StampResult;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class StampResultTest extends TestCase
 {
     public function testUsingKnownStampResponse(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('retentions-stamp-response.json'));
         $response = new StampResult($data);
         $this->assertSame('x-xml', $response->xml());

--- a/tests/Unit/Services/Retentions/StampServiceTest.php
+++ b/tests/Unit/Services/Retentions/StampServiceTest.php
@@ -8,11 +8,13 @@ use PhpCfdi\Finkok\Services\Retentions\StampCommand;
 use PhpCfdi\Finkok\Services\Retentions\StampService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class StampServiceTest extends TestCase
 {
     public function testSignStampSendXmlAndProcessPreparedResult(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('retentions-stamp-response.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/Unit/Services/Retentions/StampedResultTest.php
+++ b/tests/Unit/Services/Retentions/StampedResultTest.php
@@ -6,11 +6,13 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Retentions;
 
 use PhpCfdi\Finkok\Services\Retentions\StampedResult;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class StampedResultTest extends TestCase
 {
     public function testUsingKnownStampResponse(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('retentions-stamped-response.json'));
         $response = new StampedResult($data);
         $this->assertSame('x-xml', $response->xml());

--- a/tests/Unit/Services/Retentions/StampedServiceTest.php
+++ b/tests/Unit/Services/Retentions/StampedServiceTest.php
@@ -8,11 +8,13 @@ use PhpCfdi\Finkok\Services\Retentions\StampedCommand;
 use PhpCfdi\Finkok\Services\Retentions\StampedService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class StampedServiceTest extends TestCase
 {
     public function testSignStampSendXmlAndProcessPreparedResult(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('retentions-stamped-response.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/Unit/Services/Stamping/QueryPendingResultTest.php
+++ b/tests/Unit/Services/Stamping/QueryPendingResultTest.php
@@ -6,11 +6,13 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Stamping;
 
 use PhpCfdi\Finkok\Services\Stamping\QueryPendingResult;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class QueryPendingResultTest extends TestCase
 {
     public function testUsingKnownStampResponse(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('querypending-response.json'));
         $response = new QueryPendingResult($data);
         $this->assertSame('S', $response->status());

--- a/tests/Unit/Services/Stamping/QueryPendingServiceTest.php
+++ b/tests/Unit/Services/Stamping/QueryPendingServiceTest.php
@@ -8,11 +8,13 @@ use PhpCfdi\Finkok\Services\Stamping\QueryPendingCommand;
 use PhpCfdi\Finkok\Services\Stamping\QueryPendingService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class QueryPendingServiceTest extends TestCase
 {
     public function testCall(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('querypending-response.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/Unit/Services/Stamping/QuickStampServiceTest.php
+++ b/tests/Unit/Services/Stamping/QuickStampServiceTest.php
@@ -8,11 +8,13 @@ use PhpCfdi\Finkok\Services\Stamping\QuickStampService;
 use PhpCfdi\Finkok\Services\Stamping\StampingCommand;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class QuickStampServiceTest extends TestCase
 {
     public function testQuickStampSendXmlAndProcessPreparedResult(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('quickstamp-response-with-alerts.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/Unit/Services/Stamping/StampServiceTest.php
+++ b/tests/Unit/Services/Stamping/StampServiceTest.php
@@ -8,11 +8,13 @@ use PhpCfdi\Finkok\Services\Stamping\StampingCommand;
 use PhpCfdi\Finkok\Services\Stamping\StampService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class StampServiceTest extends TestCase
 {
     public function testStampSendXmlAndProcessPreparedResult(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('stamp-response-with-alerts.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/Unit/Services/Stamping/StampedServiceTest.php
+++ b/tests/Unit/Services/Stamping/StampedServiceTest.php
@@ -8,11 +8,13 @@ use PhpCfdi\Finkok\Services\Stamping\StampedService;
 use PhpCfdi\Finkok\Services\Stamping\StampingCommand;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class StampedServiceTest extends TestCase
 {
     public function testStampedSendXmlAndProcessPreparedResult(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('stamped-response-with-alerts.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/Unit/Services/Stamping/StampingAlertsTest.php
+++ b/tests/Unit/Services/Stamping/StampingAlertsTest.php
@@ -6,6 +6,7 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Stamping;
 
 use PhpCfdi\Finkok\Services\Stamping\StampingAlerts;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class StampingAlertsTest extends TestCase
 {
@@ -52,6 +53,7 @@ final class StampingAlertsTest extends TestCase
 
     public function testGettingAnAlertByIndex(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('stamp-response-with-alerts.json'));
         $alerts = new StampingAlerts($data->{'stampResult'}->{'Incidencias'}->{'Incidencia'} ?? []);
         $this->assertSame('FAKE2', $alerts->get(1)->errorCode());

--- a/tests/Unit/Services/Stamping/StampingResultTest.php
+++ b/tests/Unit/Services/Stamping/StampingResultTest.php
@@ -6,11 +6,13 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Stamping;
 
 use PhpCfdi\Finkok\Services\Stamping\StampingResult;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class StampingResultTest extends TestCase
 {
     public function testUsingKnownStampResponse(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('stamp-response-with-alerts.json'));
         $response = new StampingResult('stampResult', $data);
         $this->assertCount(2, $response->alerts());
@@ -18,6 +20,7 @@ final class StampingResultTest extends TestCase
 
     public function testHasAlerts(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('stamp-response-with-alerts.json'));
         $response = new StampingResult('stampResult', $data);
         $this->assertTrue($response->hasAlerts());

--- a/tests/Unit/Services/Utilities/DatetimeServiceTest.php
+++ b/tests/Unit/Services/Utilities/DatetimeServiceTest.php
@@ -8,11 +8,13 @@ use PhpCfdi\Finkok\Services\Utilities\DatetimeCommand;
 use PhpCfdi\Finkok\Services\Utilities\DatetimeService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class DatetimeServiceTest extends TestCase
 {
     public function testDatetimeServiceUsingPreparedResultWithEmptyPostalCode(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('utilities-datetime-response.json'));
 
         $soapFactory = new FakeSoapFactory();
@@ -31,6 +33,7 @@ final class DatetimeServiceTest extends TestCase
 
     public function testDatetimeServiceUsingPreparedResultWithPostalCode(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('utilities-datetime-response.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/Unit/Services/Utilities/DownloadXmlResultTest.php
+++ b/tests/Unit/Services/Utilities/DownloadXmlResultTest.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace PhpCfdi\Finkok\Tests\Unit\Services\Utilities;
 
 use PhpCfdi\Finkok\Services\Utilities\DownloadXmlResult;
-
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class DownloadXmlResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponses(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('utilities-getxml-response.json'));
         $result = new DownloadXmlResult($data);
         $this->assertSame('predefined-xml', $result->xml());

--- a/tests/Unit/Services/Utilities/DownloadXmlServiceTest.php
+++ b/tests/Unit/Services/Utilities/DownloadXmlServiceTest.php
@@ -8,11 +8,13 @@ use PhpCfdi\Finkok\Services\Utilities\DownloadXmlCommand;
 use PhpCfdi\Finkok\Services\Utilities\DownloadXmlService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class DownloadXmlServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('utilities-getxml-response.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/Unit/Services/Utilities/ReportCreditResultTest.php
+++ b/tests/Unit/Services/Utilities/ReportCreditResultTest.php
@@ -6,11 +6,13 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Utilities;
 
 use PhpCfdi\Finkok\Services\Utilities\ReportCreditResult;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class ReportCreditResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponse(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('utilities-report-credit-response.json'));
         $result = new ReportCreditResult($data);
 
@@ -33,6 +35,7 @@ final class ReportCreditResultTest extends TestCase
 
     public function testResultUsingEmptyResponse(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('utilities-report-credit-zero-items-response.json'));
         $result = new ReportCreditResult($data);
         $this->assertCount(0, $result->items());

--- a/tests/Unit/Services/Utilities/ReportCreditServiceTest.php
+++ b/tests/Unit/Services/Utilities/ReportCreditServiceTest.php
@@ -8,11 +8,13 @@ use PhpCfdi\Finkok\Services\Utilities\ReportCreditCommand;
 use PhpCfdi\Finkok\Services\Utilities\ReportCreditService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class ReportCreditServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('utilities-report-credit-response.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/Unit/Services/Utilities/ReportTotalCommandTest.php
+++ b/tests/Unit/Services/Utilities/ReportTotalCommandTest.php
@@ -142,7 +142,7 @@ final class ReportTotalCommandTest extends TestCase
         $month = intval($today->format('m'));
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Cannot combine multiple past months with current/future months');
-        new class($today, 'x-rfc', 'I', 2019, 1, $year, $month) extends ReportTotalCommand {
+        new class ($today, 'x-rfc', 'I', 2019, 1, $year, $month) extends ReportTotalCommand {
             /** @var DateTimeImmutable */
             private $today;
 

--- a/tests/Unit/Services/Utilities/ReportTotalResultTest.php
+++ b/tests/Unit/Services/Utilities/ReportTotalResultTest.php
@@ -6,11 +6,13 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Utilities;
 
 use PhpCfdi\Finkok\Services\Utilities\ReportTotalResult;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class ReportTotalResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponse(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('utilities-report-total-response.json'));
         $result = new ReportTotalResult($data);
 
@@ -20,6 +22,7 @@ final class ReportTotalResultTest extends TestCase
 
     public function testResultUsingEmptyResponse(): void
     {
+        /** @var stdClass $data */
         $data = json_decode('{"report_totalResult": {}}');
         $result = new ReportTotalResult($data);
         $this->assertSame('', $result->rfc());

--- a/tests/Unit/Services/Utilities/ReportTotalServiceTest.php
+++ b/tests/Unit/Services/Utilities/ReportTotalServiceTest.php
@@ -8,11 +8,13 @@ use PhpCfdi\Finkok\Services\Utilities\ReportTotalCommand;
 use PhpCfdi\Finkok\Services\Utilities\ReportTotalService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class ReportTotalServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('utilities-report-total-response.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/Unit/Services/Utilities/ReportUuidResultTest.php
+++ b/tests/Unit/Services/Utilities/ReportUuidResultTest.php
@@ -6,11 +6,13 @@ namespace PhpCfdi\Finkok\Tests\Unit\Services\Utilities;
 
 use PhpCfdi\Finkok\Services\Utilities\ReportUuidResult;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class ReportUuidResultTest extends TestCase
 {
     public function testResultUsingPredefinedResponse(): void
     {
+        /** @var stdClass $data */
         $data = json_decode($this->fileContentPath('utilities-report-uuid-response.json'));
         $result = new ReportUuidResult($data);
 

--- a/tests/Unit/Services/Utilities/ReportUuidServiceTest.php
+++ b/tests/Unit/Services/Utilities/ReportUuidServiceTest.php
@@ -9,11 +9,13 @@ use PhpCfdi\Finkok\Services\Utilities\ReportUuidCommand;
 use PhpCfdi\Finkok\Services\Utilities\ReportUuidService;
 use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
 use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
 
 final class ReportUuidServiceTest extends TestCase
 {
     public function testServiceUsingPreparedResult(): void
     {
+        /** @var stdClass $preparedResult */
         $preparedResult = json_decode(TestCase::fileContentPath('utilities-report-uuid-response.json'));
 
         $soapFactory = new FakeSoapFactory();

--- a/tests/_files/cancel-cancelsignature-format.xml
+++ b/tests/_files/cancel-cancelsignature-format.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Cancelacion xmlns="http://cancelacfd.sat.gob.mx" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" RfcEmisor="EKU9003173C9" Fecha="2019-01-13T14:15:16">
-  <Folios>
-    <UUID>4CE93193-9E57-4BB0-9E03-09BAB53D392E</UUID>
-    <UUID>4CE93193-9E57-4BB0-9E03-F896B148A146</UUID>
-  </Folios>
-  <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
-    <SignedInfo>
-      <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
-      <SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
-      <Reference URI="">
-        <Transforms>
-          <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
-        </Transforms>
-        <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
-        <DigestValue>iev73+hhvziRvW7pEzLD+Hnq07M=</DigestValue>
-      </Reference>
-    </SignedInfo>
-    <SignatureValue>ITD19oKA53+Y0p9d9y3hI1WU+tcPr2f+7JWTrCWjHXiOj+Rl87BOvRqFksP5xYXU371gEtwAhM4UGwZTl1DQeH5TsqQyp7v04PG3XnddYMGlZmZYp+yzKCWJBFYUBQectsfpsmk5SEDNkNzlm4t/O6fMLL/4Az1OgqKNNxVUv3v4q6540HuFCo/NgJ5YJroAnpoBMHk/kJrybExvE3hQHYTW6++4XdWYOAH8waWVdC5iMOq311WSlnm7QThWUxpeQj/ovUIjIUFGkAj/8G0LRD0VNKukkW/1gZ/3J40FIVa2I98uS7BaXYsO3KomrCX7Av6eOm31g51E0gQoUmTO2w==</SignatureValue>
-    <KeyInfo>
-      <X509Data>
-        <X509IssuerSerial>
-          <X509IssuerName>CN=AC UAT,O=SERVICIO DE ADMINISTRACION TRIBUTARIA,OU=SAT-IES Authority,emailAddress=oscar.martinez@sat.gob.mx,street=3ra cerrada de cadiz,postalCode=06370,C=MX,ST=CIUDAD DE MEXICO,L=COYOACAN,x500UniqueIdentifier=2.5.4.45,unstructuredName=responsable: ACDMA-SAT</X509IssuerName>
-          <X509SerialNumber>30001000000400002434</X509SerialNumber>
-        </X509IssuerSerial>
-        <X509Certificate>MIIFuzCCA6OgAwIBAgIUMzAwMDEwMDAwMDA0MDAwMDI0MzQwDQYJKoZIhvcNAQELBQAwggErMQ8wDQYDVQQDDAZBQyBVQVQxLjAsBgNVBAoMJVNFUlZJQ0lPIERFIEFETUlOSVNUUkFDSU9OIFRSSUJVVEFSSUExGjAYBgNVBAsMEVNBVC1JRVMgQXV0aG9yaXR5MSgwJgYJKoZIhvcNAQkBFhlvc2Nhci5tYXJ0aW5lekBzYXQuZ29iLm14MR0wGwYDVQQJDBQzcmEgY2VycmFkYSBkZSBjYWRpejEOMAwGA1UEEQwFMDYzNzAxCzAJBgNVBAYTAk1YMRkwFwYDVQQIDBBDSVVEQUQgREUgTUVYSUNPMREwDwYDVQQHDAhDT1lPQUNBTjERMA8GA1UELRMIMi41LjQuNDUxJTAjBgkqhkiG9w0BCQITFnJlc3BvbnNhYmxlOiBBQ0RNQS1TQVQwHhcNMTkwNjE3MTk0NDE0WhcNMjMwNjE3MTk0NDE0WjCB4jEnMCUGA1UEAxMeRVNDVUVMQSBLRU1QRVIgVVJHQVRFIFNBIERFIENWMScwJQYDVQQpEx5FU0NVRUxBIEtFTVBFUiBVUkdBVEUgU0EgREUgQ1YxJzAlBgNVBAoTHkVTQ1VFTEEgS0VNUEVSIFVSR0FURSBTQSBERSBDVjElMCMGA1UELRMcRUtVOTAwMzE3M0M5IC8gWElRQjg5MTExNlFFNDEeMBwGA1UEBRMVIC8gWElRQjg5MTExNk1HUk1aUjA1MR4wHAYDVQQLExVFc2N1ZWxhIEtlbXBlciBVcmdhdGUwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCN0peKpgfOL75iYRv1fqq+oVYsLPVUR/GibYmGKc9InHFy5lYF6OTYjnIIvmkOdRobbGlCUxORX/tLsl8Ya9gm6Yo7hHnODRBIDup3GISFzB/96R9K/MzYQOcscMIoBDARaycnLvy7FlMvO7/rlVnsSARxZRO8Kz8Zkksj2zpeYpjZIya/369+oGqQk1cTRkHo59JvJ4Tfbk/3iIyf4H/Ini9nBe9cYWo0MnKob7DDt/vsdi5tA8mMtA953LapNyCZIDCRQQlUGNgDqY9/8F5mUvVgkcczsIgGdvf9vMQPSf3jjCiKj7j6ucxl1+FwJWmbvgNmiaUR/0q4m2rm78lFAgMBAAGjHTAbMAwGA1UdEwEB/wQCMAAwCwYDVR0PBAQDAgbAMA0GCSqGSIb3DQEBCwUAA4ICAQBcpj1TjT4jiinIujIdAlFzE6kRwYJCnDG08zSp4kSnShjxADGEXH2chehKMV0FY7c4njA5eDGdA/G2OCTPvF5rpeCZP5Dw504RZkYDl2suRz+wa1sNBVpbnBJEK0fQcN3IftBwsgNFdFhUtCyw3lus1SSJbPxjLHS6FcZZ51YSeIfcNXOAuTqdimusaXq15GrSrCOkM6n2jfj2sMJYM2HXaXJ6rGTEgYmhYdwxWtil6RfZB+fGQ/H9I9WLnl4KTZUS6C9+NLHh4FPDhSk19fpS2S/56aqgFoGAkXAYt9Fy5ECaPcULIfJ1DEbsXKyRdCv3JY89+0MNkOdaDnsemS2o5Gl08zI4iYtt3L40gAZ60NPh31kVLnYNsmvfNxYyKp+AeJtDHyW9w7ftM0Hoi+BuRmcAQSKFV3pk8j51la+jrRBrAUv8blbRcQ5BiZUwJzHFEKIwTsRGoRyEx96sNnB03n6GTwjIGz92SmLdNl95r9rkvp+2m4S6q1lPuXaFg7DGBrXWC8iyqeWE2iobdwIIuXPTMVqQb12m1dAkJVRO5NdHnP/MpqOvOgLqoZBNHGyBg4Gqm4sCJHCxA1c8Elfa2RQTCk0tAzllL4vOnI1GHkGJn65xokGsaU4B4D36xh7eWrfj4/pgWHmtoDAYa8wzSwo2GVCZOs+mtEgOQB91/g==</X509Certificate>
-      </X509Data>
-      <KeyValue>
-        <RSAKeyValue>
-          <Modulus>jdKXiqYHzi++YmEb9X6qvqFWLCz1VEfxom2JhinPSJxxcuZWBejk2I5yCL5pDnUaG2xpQlMTkV/7S7JfGGvYJumKO4R5zg0QSA7qdxiEhcwf/ekfSvzM2EDnLHDCKAQwEWsnJy78uxZTLzu/65VZ7EgEcWUTvCs/GZJLI9s6XmKY2SMmv9+vfqBqkJNXE0ZB6OfSbyeE325P94iMn+B/yJ4vZwXvXGFqNDJyqG+ww7f77HYubQPJjLQPedy2qTcgmSAwkUEJVBjYA6mPf/BeZlL1YJHHM7CIBnb3/bzED0n944woio+4+rnMZdfhcCVpm74DZomlEf9KuJtq5u/JRQ==</Modulus>
-          <Exponent>AQAB</Exponent>
-        </RSAKeyValue>
-      </KeyValue>
-    </KeyInfo>
-  </Signature>
+<Cancelacion xmlns="http://cancelacfd.sat.gob.mx" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" RfcEmisor="EKU9003173C9" Fecha="2022-01-06T17:49:12">
+    <Folios>
+        <Folio UUID="62B00C5E-4187-4336-B569-44E0030DC729" Motivo="02" FolioSustitucion=""></Folio>
+    </Folios>
+    <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <SignedInfo>
+            <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+            <SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+            <Reference URI="">
+                <Transforms>
+                    <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+                </Transforms>
+                <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+                <DigestValue>C5CrlWmW2k+LRbwIz2JTydPW2+g=</DigestValue>
+            </Reference>
+        </SignedInfo>
+        <SignatureValue>Kxm+BjKx10C/G3c8W8IItAXgdxKP1hmBf2F4DnVcPLTKNfvRu/E29NG2PXDcXGUauAOLi13+7BT2ovURHQKNsjErmAD5Ya09gkUHNstg8ja6K3O5haTNWSIGGf1ZGi1fY8pZ/VSL32L1BnJsu3d81tnxnpriSWkqSQHG2xcll9L2qxdjxlhPfllL1D9nF1TrCv6QCGzgmnRXs6sgUz7Zb2nZaJzPPnausyktEs56LnQr+dpgGs12G8X4NyqFVo8byNA5/fSwF6WLl7RN4p9fKI1WGZg93yHLG6R1fZ+80N0vebNmRDJCHnTrO2aLOn1dkneCqBExOzj8hJMWljzWGQ==</SignatureValue>
+        <KeyInfo>
+            <X509Data>
+                <X509IssuerSerial>
+                    <X509IssuerName>CN=AC UAT,O=SERVICIO DE ADMINISTRACION TRIBUTARIA,OU=SAT-IES Authority,emailAddress=oscar.martinez@sat.gob.mx,street=3ra cerrada de cadiz,postalCode=06370,C=MX,ST=CIUDAD DE MEXICO,L=COYOACAN,x500UniqueIdentifier=2.5.4.45,unstructuredName=responsable: ACDMA-SAT</X509IssuerName>
+                    <X509SerialNumber>30001000000400002434</X509SerialNumber>
+                </X509IssuerSerial>
+                <X509Certificate>MIIFuzCCA6OgAwIBAgIUMzAwMDEwMDAwMDA0MDAwMDI0MzQwDQYJKoZIhvcNAQELBQAwggErMQ8wDQYDVQQDDAZBQyBVQVQxLjAsBgNVBAoMJVNFUlZJQ0lPIERFIEFETUlOSVNUUkFDSU9OIFRSSUJVVEFSSUExGjAYBgNVBAsMEVNBVC1JRVMgQXV0aG9yaXR5MSgwJgYJKoZIhvcNAQkBFhlvc2Nhci5tYXJ0aW5lekBzYXQuZ29iLm14MR0wGwYDVQQJDBQzcmEgY2VycmFkYSBkZSBjYWRpejEOMAwGA1UEEQwFMDYzNzAxCzAJBgNVBAYTAk1YMRkwFwYDVQQIDBBDSVVEQUQgREUgTUVYSUNPMREwDwYDVQQHDAhDT1lPQUNBTjERMA8GA1UELRMIMi41LjQuNDUxJTAjBgkqhkiG9w0BCQITFnJlc3BvbnNhYmxlOiBBQ0RNQS1TQVQwHhcNMTkwNjE3MTk0NDE0WhcNMjMwNjE3MTk0NDE0WjCB4jEnMCUGA1UEAxMeRVNDVUVMQSBLRU1QRVIgVVJHQVRFIFNBIERFIENWMScwJQYDVQQpEx5FU0NVRUxBIEtFTVBFUiBVUkdBVEUgU0EgREUgQ1YxJzAlBgNVBAoTHkVTQ1VFTEEgS0VNUEVSIFVSR0FURSBTQSBERSBDVjElMCMGA1UELRMcRUtVOTAwMzE3M0M5IC8gWElRQjg5MTExNlFFNDEeMBwGA1UEBRMVIC8gWElRQjg5MTExNk1HUk1aUjA1MR4wHAYDVQQLExVFc2N1ZWxhIEtlbXBlciBVcmdhdGUwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCN0peKpgfOL75iYRv1fqq+oVYsLPVUR/GibYmGKc9InHFy5lYF6OTYjnIIvmkOdRobbGlCUxORX/tLsl8Ya9gm6Yo7hHnODRBIDup3GISFzB/96R9K/MzYQOcscMIoBDARaycnLvy7FlMvO7/rlVnsSARxZRO8Kz8Zkksj2zpeYpjZIya/369+oGqQk1cTRkHo59JvJ4Tfbk/3iIyf4H/Ini9nBe9cYWo0MnKob7DDt/vsdi5tA8mMtA953LapNyCZIDCRQQlUGNgDqY9/8F5mUvVgkcczsIgGdvf9vMQPSf3jjCiKj7j6ucxl1+FwJWmbvgNmiaUR/0q4m2rm78lFAgMBAAGjHTAbMAwGA1UdEwEB/wQCMAAwCwYDVR0PBAQDAgbAMA0GCSqGSIb3DQEBCwUAA4ICAQBcpj1TjT4jiinIujIdAlFzE6kRwYJCnDG08zSp4kSnShjxADGEXH2chehKMV0FY7c4njA5eDGdA/G2OCTPvF5rpeCZP5Dw504RZkYDl2suRz+wa1sNBVpbnBJEK0fQcN3IftBwsgNFdFhUtCyw3lus1SSJbPxjLHS6FcZZ51YSeIfcNXOAuTqdimusaXq15GrSrCOkM6n2jfj2sMJYM2HXaXJ6rGTEgYmhYdwxWtil6RfZB+fGQ/H9I9WLnl4KTZUS6C9+NLHh4FPDhSk19fpS2S/56aqgFoGAkXAYt9Fy5ECaPcULIfJ1DEbsXKyRdCv3JY89+0MNkOdaDnsemS2o5Gl08zI4iYtt3L40gAZ60NPh31kVLnYNsmvfNxYyKp+AeJtDHyW9w7ftM0Hoi+BuRmcAQSKFV3pk8j51la+jrRBrAUv8blbRcQ5BiZUwJzHFEKIwTsRGoRyEx96sNnB03n6GTwjIGz92SmLdNl95r9rkvp+2m4S6q1lPuXaFg7DGBrXWC8iyqeWE2iobdwIIuXPTMVqQb12m1dAkJVRO5NdHnP/MpqOvOgLqoZBNHGyBg4Gqm4sCJHCxA1c8Elfa2RQTCk0tAzllL4vOnI1GHkGJn65xokGsaU4B4D36xh7eWrfj4/pgWHmtoDAYa8wzSwo2GVCZOs+mtEgOQB91/g==</X509Certificate>
+            </X509Data>
+            <KeyValue>
+                <RSAKeyValue>
+                    <Modulus>jdKXiqYHzi++YmEb9X6qvqFWLCz1VEfxom2JhinPSJxxcuZWBejk2I5yCL5pDnUaG2xpQlMTkV/7S7JfGGvYJumKO4R5zg0QSA7qdxiEhcwf/ekfSvzM2EDnLHDCKAQwEWsnJy78uxZTLzu/65VZ7EgEcWUTvCs/GZJLI9s6XmKY2SMmv9+vfqBqkJNXE0ZB6OfSbyeE325P94iMn+B/yJ4vZwXvXGFqNDJyqG+ww7f77HYubQPJjLQPedy2qTcgmSAwkUEJVBjYA6mPf/BeZlL1YJHHM7CIBnb3/bzED0n944woio+4+rnMZdfhcCVpm74DZomlEf9KuJtq5u/JRQ==</Modulus>
+                    <Exponent>AQAB</Exponent>
+                </RSAKeyValue>
+            </KeyValue>
+        </KeyInfo>
+    </Signature>
 </Cancelacion>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,7 +20,6 @@ call_user_func(new class () {
             return;
         }
         $dotEnv = new Symfony\Component\Dotenv\Dotenv();
-        $dotEnv->usePutenv(true);
         $dotEnv->load($environmentFile);
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,7 +11,7 @@ date_default_timezone_set('America/Mexico_City');
 // require composer autoloader
 require_once __DIR__ . '/../vendor/autoload.php';
 
-call_user_func(new class() {
+call_user_func(new class () {
     public function __invoke(): void
     {
         $environmentFile = __DIR__ . '/.env';

--- a/tests/stamp-precfdi-devenv.php
+++ b/tests/stamp-precfdi-devenv.php
@@ -13,7 +13,7 @@ use Throwable;
 
 require_once __DIR__ . '/bootstrap.php';
 
-exit(call_user_func(new class($argv[1] ?? '') {
+exit(call_user_func(new class ($argv[1] ?? '') {
     /** @var string */
     private $command;
 
@@ -66,7 +66,7 @@ exit(call_user_func(new class($argv[1] ?? '') {
                 sprintf("%s: %s\n", get_class($exception), $exception->getMessage()),
                 FILE_APPEND
             );
-            return $exception->getCode() ?: 1;
+            return (int) $exception->getCode() ?: 1;
         }
     }
 

--- a/tests/stamp-precfdi-devenv.php
+++ b/tests/stamp-precfdi-devenv.php
@@ -28,7 +28,7 @@ exit(call_user_func(new class ($argv[1] ?? '') {
             $this->showHelp();
             return 0;
         }
-        $debug = boolval(getenv('FINKOK_LOG_CALLS'));
+        $debug = (bool) TestCase::getenv('FINKOK_LOG_CALLS');
         try {
             if (! file_exists($preCfdiPath)) {
                 throw new Exception("File $preCfdiPath does not exists");
@@ -39,8 +39,8 @@ exit(call_user_func(new class ($argv[1] ?? '') {
             }
 
             $settings = new FinkokSettings(
-                strval(getenv('FINKOK_USERNAME')) ?: 'username-non-set',
-                strval(getenv('FINKOK_PASSWORD')) ?: 'password-non-set',
+                TestCase::getenv('FINKOK_USERNAME') ?: 'username-non-set',
+                TestCase::getenv('FINKOK_PASSWORD') ?: 'password-non-set',
                 FinkokEnvironment::makeDevelopment()
             );
             if ($debug) {


### PR DESCRIPTION
Se actualiza a [`phpcfdi/xml-cancelacion`](https://github.com/phpcfdi/xml-cancelacion) que incluye los
formatos a utilizar para la cancelación 2022 según la nueva especificación del SAT.
Esto provoca cambios importantes en todos los métodos relacionados con la cancelación.

Se elimina `CancelledDocument::cancellationSatatus()`. Se debe usar `CancelledDocument::cancellationStatus()`.

Se actualiza la licencia a 2022. ¡Feliz año!

Se hacen varios cambios al entorno de desarrollo:

- Se agregan nuevos casos para el error de estampado `707`.
- Se cambian las dependencias de desarrollo a `phive`.
- Ya no se usa `\getenv`, en su lugar se pone una función segura en `TestCase::getenv`.
- Se corrigen las incidencias encontradas por PHPStan 1.3.3.
