### PR TITLE
Versión 0.4.1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # see https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
-/.github/*  @phpcfdi/core-mantainers
+/.github/*  @phpcfdi/core-maintainers

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,58 +1,105 @@
 name: build
 on:
   pull_request:
-    branches: [ 'main' ]
+    branches: [ "main" ]
   push:
-    branches: [ 'main' ]
+    branches: [ "main" ]
   schedule:
     - cron: '0 16 * * 0' # sunday 16:00
 
 jobs:
-  build:
-    name: PHP ${{ matrix.php-versions }}
+
+  phpcs:
+    name: Code style (phpcs)
     runs-on: "ubuntu-latest"
-
-    strategy:
-      matrix:
-        php-versions: ['7.3', '7.4', '8.0']
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      # see https://github.com/marketplace/actions/setup-php-action
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@v2 # see https://github.com/marketplace/actions/setup-php-action
         with:
-          php-version: ${{ matrix.php-versions }}
-          extensions: json, soap, dom, openssl
+          php-version: '8.0'
           coverage: none
-          tools: composer:v2, cs2pr, phpcs, php-cs-fixer, phpstan
+          tools: composer:v2, cs2pr, phpcs
         env:
           fail-fast: true
+      - name: Code style (phpcs)
+        run: phpcs -q --report=checkstyle src/ tests/ | cs2pr
 
+  php-cs-fixer:
+    name: Code style (php-cs-fixer)
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2 # see https://github.com/marketplace/actions/setup-php-action
+        with:
+          php-version: '8.0'
+          coverage: none
+          tools: composer:v2, cs2pr, php-cs-fixer
+        env:
+          fail-fast: true
+      - name: Code style (php-cs-fixer)
+        run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
+
+  phpstan:
+    name: Code analysis (phpstan)
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2 # see https://github.com/marketplace/actions/setup-php-action
+        with:
+          php-version: '8.0'
+          coverage: none
+          tools: composer:v2, cs2pr, phpstan
+          extensions: soap
+        env:
+          fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
-
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
-
-      - name: Code style (phpcs)
-        run: phpcs -q --report=checkstyle | cs2pr
-
-      - name: Code style (php-cs-fixer)
-        run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
-
-      - name: Unit tests (phpunit)
-        run: vendor/bin/phpunit tests/Unit/ --testdox --verbose
-
-      - name: Code analysis (phpstan)
+      - name: PHPStan
         run: phpstan analyse --no-progress --verbose
+
+  unit-tests:
+    name: Tests on PHP ${{ matrix.php-versions }}
+    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        php-versions: ['7.3', '7.4', '8.0']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2 # see https://github.com/marketplace/actions/setup-php-action
+        with:
+          php-version: ${{ matrix.php-versions }}
+          coverage: none
+          tools: composer:v2
+          extensions: soap
+        env:
+          fail-fast: true
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install project dependencies
+        run: composer upgrade --no-interaction --no-progress --prefer-dist
+      - name: Tests (phpunit)
+        run: vendor/bin/phpunit tests/Unit/ --testdox --verbose

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -20,7 +20,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "8.0"
-          extensions: json, soap, dom, openssl
+          extensions: soap
           coverage: xdebug
           tools: composer:v2
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,8 +96,8 @@ muestra en [`actions/setup-php-action`](https://github.com/marketplace/actions/s
 puedes ejecutar el siguiente comando:
 
 ```shell
-act -P ubuntu-latest=shivammathur/node:latest -j build
-act -P ubuntu-latest=shivammathur/node:latest -j functional-tests -s ENV_GPG_SECRET=**********
+act -P ubuntu-latest=shivammathur/node:latest -W .github/workflows/build.yml
+act -P ubuntu-latest=shivammathur/node:latest -W .github/workflows/functional-tests.yml -s ENV_GPG_SECRET=**********
 ```
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor el control de versiones.
 
+## Version 0.4.1 2022-01-11
+
+Se hacen cambios menores y de mantenimiento:
+
+- Se remueven conversiones de tipos innecesarios.
+- Se corrige el ejemplo de cancelación usando `QuickFinkok`.
+- Se actualizan los tests para un mejor entendimiento y ya no se usan métodos deprecados.
+- Se corrige el nombre del grupo mantenedor de PhpCfdi.
+
 ## Version 0.4.0 2022-01-09
 
 Se actualiza a [`phpcfdi/xml-cancelacion`](https://github.com/phpcfdi/xml-cancelacion) que incluye los

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ Se hacen cambios menores y de mantenimiento:
 - Se corrige el ejemplo de cancelación usando `QuickFinkok`.
 - Se actualizan los tests para un mejor entendimiento y ya no se usan métodos deprecados.
 - Se corrige el nombre del grupo mantenedor de PhpCfdi.
+- Se cambia el flujo de integración continua de pasos en el trabajo a trabajos separados.
 
 ## Version 0.4.0 2022-01-09
 

--- a/docs/Ejemplos/CancelacionFirmada.md
+++ b/docs/Ejemplos/CancelacionFirmada.md
@@ -72,7 +72,6 @@ echo $result->statusCode(); // código de estado de la solucitud de cancelación
 ## Ejemplo usando phpcfdi/xml-cancelacion
 
 Para crear el XML de cancelación está usando [`phpcfdi/xml-cancelacion`](https://github.com/phpcfdi/xml-cancelacion).
-Puedes instalar vía composer tanto esta librería como la que genera xml firmados para cancelación.
 
 ```shell
 composer require phpcfdi/finkok

--- a/docs/Ejemplos/CancelacionFirmada.md
+++ b/docs/Ejemplos/CancelacionFirmada.md
@@ -15,16 +15,22 @@ use PhpCfdi\Finkok\FinkokEnvironment;
 use PhpCfdi\Finkok\FinkokSettings;
 use PhpCfdi\Finkok\QuickFinkok;
 use PhpCfdi\XmlCancelacion\Models\CancelDocument;
-use PhpCfdi\XmlCancelacion\Models\CancelDocuments;
 
-$uuid = '12345678-1234-1234-1234-000000000001';
-$related = '12345678-1234-1234-1234-000000000AAA';
+// Crear el objeto QuickFinkok
 $credential = Credential::openFiles('certificado.cer', 'llave-privada.key.pem', '12345678a');
-$finkok = new QuickFinkok(new FinkokSettings('finkok-usuario', 'finkok-password', FinkokEnvironment::makeProduction()));
+$quickFinkok = new QuickFinkok(new FinkokSettings('finkok-usuario', 'finkok-password', FinkokEnvironment::makeProduction()));
 
-$result = $finkok->cancel($credential, new CancelDocuments(CancelDocument::newWithErrorsRelated($uuid, $related)));
+// Crear el documento a cancelar (cancelado con relación)
+$documentToCancel = CancelDocument::newWithErrorsRelated(
+    '12345678-1234-1234-1234-000000000001',  // el UUID a cancelar
+    '12345678-1234-1234-1234-000000000AAA'   // el UUID que lo sustituye
+);
+
+// Presentar la solicitud de cancelación
+$result = $quickFinkok->cancel($credential, $documentToCancel);
 $documentInfo = $result->documents()->first();
 
+// Trabajar con la respuesta
 echo 'Código de estado de la solicitud de cancelación: ', $result->statusCode();
 echo 'UUID: ', $documentInfo->uuid();
 echo 'Estado del CFDI: ', $documentInfo->documentStatus();

--- a/src/Services/Manifest/GetContractsResult.php
+++ b/src/Services/Manifest/GetContractsResult.php
@@ -33,16 +33,16 @@ class GetContractsResult extends AbstractResult
 
     public function contract(): string
     {
-        return base64_decode(strval($this->get('contract')), true) ?: '';
+        return base64_decode($this->get('contract'), true) ?: '';
     }
 
     public function privacy(): string
     {
-        return base64_decode(strval($this->get('privacy')), true) ?: '';
+        return base64_decode($this->get('privacy'), true) ?: '';
     }
 
     public function error(): string
     {
-        return strval($this->get('error'));
+        return $this->get('error');
     }
 }

--- a/src/Services/Manifest/GetSignedContractsResult.php
+++ b/src/Services/Manifest/GetSignedContractsResult.php
@@ -25,9 +25,9 @@ class GetSignedContractsResult extends AbstractResult
     {
         parent::__construct($data, 'get_documentsResult');
         $this->success = boolval($this->get('success'));
-        $this->contract = strval($this->get('contract'));
-        $this->privacy = strval($this->get('privacy'));
-        $this->error = strval($this->get('error'));
+        $this->contract = $this->get('contract');
+        $this->privacy = $this->get('privacy');
+        $this->error = $this->get('error');
         if ($isBase64) {
             $this->contract = base64_decode($this->contract) ?: '';
             $this->privacy = base64_decode($this->privacy) ?: '';

--- a/src/Services/Manifest/SignContractsResult.php
+++ b/src/Services/Manifest/SignContractsResult.php
@@ -31,6 +31,6 @@ class SignContractsResult extends AbstractResult
 
     public function message(): string
     {
-        return strval($this->get('message'));
+        return $this->get('message');
     }
 }

--- a/src/Services/Registration/AddResult.php
+++ b/src/Services/Registration/AddResult.php
@@ -21,6 +21,6 @@ class AddResult extends AbstractResult
 
     public function message(): string
     {
-        return strval($this->get('message'));
+        return $this->get('message');
     }
 }

--- a/src/Services/Registration/AssignResult.php
+++ b/src/Services/Registration/AssignResult.php
@@ -26,6 +26,6 @@ class AssignResult extends AbstractResult
 
     public function message(): string
     {
-        return strval($this->get('message'));
+        return $this->get('message');
     }
 }

--- a/src/Services/Registration/Customer.php
+++ b/src/Services/Registration/Customer.php
@@ -20,7 +20,7 @@ class Customer
     public function __construct(stdClass $raw)
     {
         $this->data = $raw;
-        $rawStatus = strval($this->get('status'));
+        $rawStatus = $this->get('status');
         if (in_array($rawStatus, CustomerStatus::toArray())) {
             $this->status = new CustomerStatus($rawStatus);
         } else {

--- a/src/Services/Registration/EditResult.php
+++ b/src/Services/Registration/EditResult.php
@@ -21,6 +21,6 @@ class EditResult extends AbstractResult
 
     public function message(): string
     {
-        return strval($this->get('message'));
+        return $this->get('message');
     }
 }

--- a/src/Services/Registration/SwitchResult.php
+++ b/src/Services/Registration/SwitchResult.php
@@ -21,6 +21,6 @@ class SwitchResult extends AbstractResult
 
     public function message(): string
     {
-        return strval($this->get('message'));
+        return $this->get('message');
     }
 }

--- a/src/Services/Utilities/ReportTotalCommand.php
+++ b/src/Services/Utilities/ReportTotalCommand.php
@@ -76,7 +76,7 @@ class ReportTotalCommand
         }
 
         if ($this->startPeriod < $this->endPeriod && $this->endPeriod >= $currentPeriod) {
-            throw new LogicException(sprintf('Cannot combine multiple past months with current/future months'));
+            throw new LogicException('Cannot combine multiple past months with current/future months');
         }
     }
 

--- a/tests/Integration/Services/Registration/README.md
+++ b/tests/Integration/Services/Registration/README.md
@@ -1,3 +1,4 @@
+# Pruebas de registro de clientes
 
 No existe un servicio de integración para eliminar clientes registrados.
 
@@ -37,4 +38,4 @@ Se espera que el RFC ABCD010101AAA (que es inválido) no esté registrado.
 Se espera que el RFC XDEL000101XX1 esté registrado.
 
 La prueba consiste en obtener el registro actual, marcarlo como activo si no lo está,
-cambiarlo a suspendido, cambiarlo a activo.
+cambiarlo a estado suspendido, cambiarlo a estado activo.

--- a/tests/Integration/Services/Retentions/CancelSignatureServiceTest.php
+++ b/tests/Integration/Services/Retentions/CancelSignatureServiceTest.php
@@ -49,10 +49,11 @@ final class CancelSignatureServiceTest extends RetentionsTestCase
             );
             $document = $result->documents()->first();
 
-            // do not try again if a SAT issue is **not** found
-            // 1205 - UUID no existe (¿el SAT aun no lo tiene?)
-            // 1308 - Certificado revocado o caduco (¿el SAT tiene problemas de tiempo?)
-            if (! in_array($document->documentStatus(), ['1205', '1308'])) {
+            // do not try again if a SAT issue is **different** from:
+            // 708: Finkok cannot connect to SAT
+            // 1205: UUID no existe (¿el SAT aún no lo tiene?)
+            // 1308: Certificado revocado o caduco (¿el SAT tiene problemas de tiempo?)
+            if (! in_array($document->documentStatus(), ['708', '1205', '1308'], true)) {
                 break;
             }
 

--- a/tests/Unit/FinkokTest.php
+++ b/tests/Unit/FinkokTest.php
@@ -137,7 +137,7 @@ final class FinkokTest extends TestCase
         /** @var FinkokSettings&MockObject $settings */
         $settings = $this->createMock(FinkokSettings::class);
         $exposer = new class ($settings) extends Finkok {
-            /** @return array<array<mixed>> */
+            /** @return array<string, string[]> */
             public function exposeServicesMap(): array
             {
                 return parent::SERVICES_MAP;

--- a/tests/Unit/QuickFinkokTest.php
+++ b/tests/Unit/QuickFinkokTest.php
@@ -407,7 +407,7 @@ final class QuickFinkokTest extends TestCase
         /** @var QuickFinkok&MockObject $finkok */
         $finkok = $this->getMockBuilder(QuickFinkok::class)
             ->disableOriginalConstructor()
-            ->setMethodsExcept(['customerSignAndSendContracts'])
+            ->onlyMethods(['customerGetContracts', 'customerSendContracts'])
             ->getMock();
         $finkok->expects($this->once())
             ->method('customerGetContracts')->willReturn($getContractsResult)
@@ -436,7 +436,7 @@ final class QuickFinkokTest extends TestCase
         /** @var QuickFinkok&MockObject $finkok */
         $finkok = $this->getMockBuilder(QuickFinkok::class)
             ->disableOriginalConstructor()
-            ->setMethodsExcept(['customerSignAndSendContracts'])
+            ->onlyMethods(['customerGetContracts'])
             ->getMock();
         $finkok->expects($this->once())->method('customerGetContracts')->willReturn($getContractsResult);
         $result = $finkok->customerSignAndSendContracts($fiel, 'x-snid', 'x-address', 'x-email');

--- a/tests/Unit/Services/AbstractResultTest.php
+++ b/tests/Unit/Services/AbstractResultTest.php
@@ -50,7 +50,6 @@ final class AbstractResultTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unable to find mean object at /other');
-        /** @noinspection PhpExpressionResultUnusedInspection */
         new TestingResult($this->data, 'other');
     }
 

--- a/tests/stamp-precfdi-devenv.php
+++ b/tests/stamp-precfdi-devenv.php
@@ -73,7 +73,7 @@ exit(call_user_func(new class ($argv[1] ?? '') {
     public function showHelp(): void
     {
         $commandName = basename($this->command);
-        echo "{$commandName}: Try to stamp a precfdi file in development environment", PHP_EOL,
+        echo "$commandName: Try to stamp a precfdi file in development environment", PHP_EOL,
             "Syntax: $commandName precfdi-path", PHP_EOL,
             '  precfdi-path: Precfdi Location', PHP_EOL,
             'Environment (See .env file):', PHP_EOL,


### PR DESCRIPTION
Se hacen cambios menores y de mantenimiento:

- Se remueven conversiones de tipos innecesarios.
- Se corrige el ejemplo de cancelación usando `QuickFinkok`.
- Se actualizan los tests para un mejor entendimiento y ya no se usan métodos deprecados.
- Se corrige el nombre del grupo mantenedor de PhpCfdi.