### PR TITLE
Corrección de build (fix phpstan issues) y mantenimiento [v0.4.2]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,28 +14,28 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2 # see https://github.com/marketplace/actions/setup-php-action
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
           tools: composer:v2, cs2pr, phpcs
         env:
           fail-fast: true
       - name: Code style (phpcs)
-        run: phpcs -q --report=checkstyle src/ tests/ | cs2pr
+        run: phpcs -q --report=checkstyle | cs2pr
 
   php-cs-fixer:
     name: Code style (php-cs-fixer)
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2 # see https://github.com/marketplace/actions/setup-php-action
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
           tools: composer:v2, cs2pr, php-cs-fixer
         env:
@@ -48,11 +48,11 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2 # see https://github.com/marketplace/actions/setup-php-action
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
           tools: composer:v2, cs2pr, phpstan
           extensions: soap
@@ -62,7 +62,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -77,10 +77,10 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0']
+        php-versions: ['7.3', '7.4', '8.0', '8.1']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2 # see https://github.com/marketplace/actions/setup-php-action
         with:
@@ -94,7 +94,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -13,13 +13,13 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # see https://github.com/marketplace/actions/setup-php-action
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.0"
+          php-version: '8.1'
           extensions: soap
           coverage: xdebug
           tools: composer:v2
@@ -31,7 +31,7 @@ jobs:
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -2,6 +2,6 @@
 <phive xmlns="https://phar.io/phive">
   <phar name="phpcs" version="^3.6.2" installed="3.6.2" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.6.2" installed="3.6.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.4.0" installed="3.4.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="^1.3.3" installed="1.3.3" location="./tools/phpstan" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.8.0" installed="3.8.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpstan" version="^1.7.5" installed="1.7.5" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor el control de versiones.
 
+## Version 0.4.2 2022-05-30
+
+Se hacen cambios menores y de mantenimiento:
+
+- Se corrige `Finkok::checkCommand` pues podría llamar a la función `is_a` con un parámetro que no es un objeto.
+- 
+
 ## Version 0.4.1 2022-01-11
 
 Se hacen cambios menores y de mantenimiento:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,11 @@ Se hacen cambios menores y de mantenimiento:
 
 - Se corrige `Finkok::checkCommand` pues podría llamar a la función `is_a` con un parámetro que no es un objeto.
 - Se actualizan las versiones de herramientas de desarrollo `phpstan` y `php-cs-fixer`.
+- Correcciones al proceso de integración continua `build`:
+  - Los trabajos se ejecutan en PHP 8.1.
+  - Se agrega PHP 8.1 a la matriz de pruebas.
+  - `phpcs` usa los directorios configurados en `phpcs.xml.dist`.
+  - Las acciones de github se actualizan a la versión 3.
 
 ## Version 0.4.1 2022-01-11
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor e
 Se hacen cambios menores y de mantenimiento:
 
 - Se corrige `Finkok::checkCommand` pues podría llamar a la función `is_a` con un parámetro que no es un objeto.
-- 
+- Se actualizan las versiones de herramientas de desarrollo `phpstan` y `php-cs-fixer`.
 
 ## Version 0.4.1 2022-01-11
 

--- a/src/Finkok.php
+++ b/src/Finkok.php
@@ -41,7 +41,7 @@ use PhpCfdi\Finkok\Services\Utilities;
  */
 class Finkok
 {
-    /** @var array<string, string[]> */
+    /** @var array<string, array{0: class-string, 1: class-string, 2?: string}> */
     protected const SERVICES_MAP = [
         'stamp' => [Stamping\StampService::class, Stamping\StampingCommand::class],
         'quickstamp' => [Stamping\QuickStampService::class, Stamping\StampingCommand::class],
@@ -125,8 +125,7 @@ class Finkok
         if ('' === $expected) {
             return null;
         }
-        /** @var object|string $command */
-        if (! is_a($command, $expected)) {
+        if (! is_object($command) || ! is_a($command, $expected)) {
             $type = (is_object($command)) ? get_class($command) : gettype($command);
             throw new InvalidArgumentException(
                 sprintf('Call %s::%s expect %s but received %s', static::class, $method, $expected, $type)


### PR DESCRIPTION
- Se corrige `Finkok::checkCommand` pues podría llamar a la función `is_a` con un parámetro que no es un objeto.
- Se actualizan las versiones de herramientas de desarrollo `phpstan` y `php-cs-fixer`.
- Correcciones al proceso de integración continua `build`:
  - Los trabajos se ejecutan en PHP 8.1.
  - Se agrega PHP 8.1 a la matriz de pruebas.
  - `phpcs` usa los directorios configurados en `phpcs.xml.dist`.
  - Las acciones de github se actualizan a la versión 3.