### PR TITLE
Corregir URL con doble slash

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor el control de versiones.
 
+## Versión 0.4.4 2022-06-29
+
+El servidor de producción de Quadrum (para firmar manifiestos) es más estricto que el servidor de pruebas
+y no acepta la URL `https://manifiesto.cfdiquadrum.com.mx//servicios/soap/firmar.wsdl`.
+En esta versión se elimina la doble diagonal.
+
 ## Versión 0.4.3 2022-06-27
 
 Se agrega CFDI 4.0 al extractor de información `GetSatStatusExtractor`.

--- a/src/FinkokEnvironment.php
+++ b/src/FinkokEnvironment.php
@@ -46,6 +46,6 @@ class FinkokEnvironment
             $environment = (new Definitions\EnvironmentManifest($environment->index()));
         }
 
-        return $environment->value() . $service->value();
+        return rtrim($environment->value(), '/') . '/' . ltrim($service->value(), '/');
     }
 }

--- a/tests/Unit/FinkokEnvironmentTest.php
+++ b/tests/Unit/FinkokEnvironmentTest.php
@@ -31,8 +31,10 @@ final class FinkokEnvironmentTest extends TestCase
 
         $cancel = $environment->endpoint(Services::cancel());
         $this->assertStringStartsWith($environment->server(), $cancel);
+        $this->assertStringNotContainsString('//', substr($cancel, 8));
 
         $manifest = $environment->endpoint(Services::manifest());
         $this->assertStringStartsWith(EnvironmentManifest::development()->value(), $manifest);
+        $this->assertStringNotContainsString('//', substr($manifest, 8));
     }
 }


### PR DESCRIPTION
El servidor de producción de Quadrum (para firmar manifiestos) es más estricto que el servidor de pruebas y no acepta la URL `https://manifiesto.cfdiquadrum.com.mx//servicios/soap/firmar.wsdl`.
En esta versión se elimina la doble diagonal.