### PR TITLE
Version 0.5.0 - Fix get_contracts and psr/log dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,23 @@ on:
 
 jobs:
 
+  composer-normalize:
+    name: Composer normalization
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2 # see https://github.com/marketplace/actions/setup-php-action
+        with:
+          php-version: '8.1'
+          coverage: none
+          tools: composer-normalize
+        env:
+          fail-fast: true
+      - name: Composer normalize
+        run: composer-normalize
+
   phpcs:
     name: Code style (phpcs)
     runs-on: "ubuntu-latest"
@@ -20,7 +37,7 @@ jobs:
         with:
           php-version: '8.1'
           coverage: none
-          tools: composer:v2, cs2pr, phpcs
+          tools: cs2pr, phpcs
         env:
           fail-fast: true
       - name: Code style (phpcs)
@@ -37,7 +54,7 @@ jobs:
         with:
           php-version: '8.1'
           coverage: none
-          tools: composer:v2, cs2pr, php-cs-fixer
+          tools: cs2pr, php-cs-fixer
         env:
           fail-fast: true
       - name: Code style (php-cs-fixer)
@@ -54,7 +71,7 @@ jobs:
         with:
           php-version: '8.1'
           coverage: none
-          tools: composer:v2, cs2pr, phpstan
+          tools: composer:v2, phpstan
           extensions: soap
         env:
           fail-fast: true

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -4,4 +4,5 @@
   <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
   <phar name="php-cs-fixer" version="^3.9.5" installed="3.9.5" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpstan" version="^1.8.2" installed="1.8.2" location="./tools/phpstan" copy="false"/>
+  <phar name="composer-normalize" version="^2.28.3" installed="2.28.3" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "require-dev": {
         "ext-fileinfo": "*",
-        "symfony/dotenv": "^5.1",
+        "symfony/dotenv": "^5.1|^6.0",
         "eclipxe/cfdiutils": "^2.23.2",
         "phpunit/phpunit": "^9.5.10"
     },

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "ext-fileinfo": "*",
         "symfony/dotenv": "^5.1|^6.0",
         "eclipxe/cfdiutils": "^2.23.2",
-        "phpunit/phpunit": "^9.5.10"
+        "phpunit/phpunit": "^9.5.10",
+        "phpcfdi/rfc": "^1.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "ext-soap": "*",
         "ext-dom": "*",
         "ext-openssl": "*",
-        "psr/log": "^1.1",
+        "psr/log": "^1.1|^2.0|^3.0",
         "eclipxe/enum": "^0.2.0",
         "phpcfdi/credentials": "^1.0.1",
         "phpcfdi/xml-cancelacion": "^2.0.1",

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,13 @@
 {
     "name": "phpcfdi/finkok",
     "description": "Librería para conectar con la API de servicios de FINKOK",
-    "keywords": ["phpcfdi", "sat", "cfdi", "finkok"],
-    "homepage": "https://github.com/phpcfdi/finkok",
     "license": "MIT",
+    "keywords": [
+        "phpcfdi",
+        "sat",
+        "cfdi",
+        "finkok"
+    ],
     "authors": [
         {
             "name": "Carlos C Soto",
@@ -11,38 +15,33 @@
             "homepage": "https://eclipxe.com.mx/"
         }
     ],
+    "homepage": "https://github.com/phpcfdi/finkok",
     "support": {
-        "source": "https://github.com/phpcfdi/finkok",
-        "issues": "https://github.com/phpcfdi/finkok/issues"
-    },
-    "prefer-stable": true,
-    "config": {
-        "optimize-autoloader": true,
-        "preferred-install": {
-            "*": "dist"
-        }
+        "issues": "https://github.com/phpcfdi/finkok/issues",
+        "source": "https://github.com/phpcfdi/finkok"
     },
     "require": {
         "php": ">=7.3",
-        "ext-json": "*",
-        "ext-soap": "*",
         "ext-dom": "*",
+        "ext-json": "*",
         "ext-openssl": "*",
-        "psr/log": "^1.1|^2.0|^3.0",
+        "ext-soap": "*",
         "eclipxe/enum": "^0.2.0",
+        "eclipxe/micro-catalog": "^0.1.0",
+        "phpcfdi/cfdi-expresiones": "^3.2",
         "phpcfdi/credentials": "^1.0.1",
         "phpcfdi/xml-cancelacion": "^2.0.1",
-        "robrichards/xmlseclibs": "^3.0.4",
-        "eclipxe/micro-catalog": "^0.1.0",
-        "phpcfdi/cfdi-expresiones": "^3.2"
+        "psr/log": "^1.1 || ^2.0 || ^3.0",
+        "robrichards/xmlseclibs": "^3.0.4"
     },
     "require-dev": {
         "ext-fileinfo": "*",
-        "symfony/dotenv": "^5.1|^6.0",
         "eclipxe/cfdiutils": "^2.23.2",
+        "phpcfdi/rfc": "^1.1",
         "phpunit/phpunit": "^9.5.10",
-        "phpcfdi/rfc": "^1.1"
+        "symfony/dotenv": "^5.1 || ^6.0"
     },
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "PhpCfdi\\Finkok\\": "src/"
@@ -53,29 +52,41 @@
             "PhpCfdi\\Finkok\\Tests\\": "tests/"
         }
     },
+    "config": {
+        "optimize-autoloader": true,
+        "preferred-install": {
+            "*": "dist"
+        }
+    },
     "scripts": {
-        "dev:build": ["@dev:fix-style", "@dev:check-style", "@dev:test"],
+        "dev:build": [
+            "@dev:fix-style",
+            "@dev:check-style",
+            "@dev:test"
+        ],
         "dev:check-style": [
+            "@php tools/composer-normalize normalize --dry-run",
             "@php tools/php-cs-fixer fix --dry-run --verbose",
             "@php tools/phpcs --colors -sp"
         ],
+        "dev:coverage": [
+            "@php -dzend_extension=xdebug.so vendor/bin/phpunit --verbose --coverage-html build/coverage/html/"
+        ],
         "dev:fix-style": [
+            "@php tools/composer-normalize normalize",
             "@php tools/php-cs-fixer fix --verbose",
             "@php tools/phpcbf --colors -sp"
         ],
         "dev:test": [
             "@php vendor/bin/phpunit --testdox --verbose --stop-on-failure tests/Unit",
             "@php tools/phpstan analyse --no-progress --verbose"
-        ],
-        "dev:coverage": [
-            "@php -dzend_extension=xdebug.so vendor/bin/phpunit --verbose --coverage-html build/coverage/html/"
         ]
     },
     "scripts-descriptions": {
         "dev:build": "DEV: run dev:fix-style dev:check-style and dev:tests, run before pull request",
-        "dev:check-style": "DEV: search for code style errors using php-cs-fixer and phpcs",
-        "dev:fix-style": "DEV: fix code style errors using php-cs-fixer and phpcbf",
-        "dev:test": "DEV: run phpunit and phpstan",
-        "dev:coverage": "DEV: run phpunit with xdebug and storage coverage in build/coverage/html/"
+        "dev:check-style": "DEV: search for code style errors using composer-normalize, php-cs-fixer and phpcs",
+        "dev:coverage": "DEV: run phpunit with xdebug and storage coverage in build/coverage/html/",
+        "dev:fix-style": "DEV: fix code style errors using composer-normalize, php-cs-fixer and phpcbf",
+        "dev:test": "DEV: run phpunit and phpstan"
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,21 +2,65 @@
 
 Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor el control de versiones.
 
-## Unreleased 2022-08-08
+## Versión 0.5.0 2022-08-12
+
+### Implementación del método `get_contracts_sndi`
+
+Se utiliza el nuevo método `get_contracts_sndi` en lugar del obsoleto `get_contracts`.
+Esto lleva a que la clase `PhpCfdi\Finkok\Services\Manifest\GetContractsCommand` ahora requiere de `$snid`.
+Igualmente, `PhpCfdi\Finkok\QuickFinkok#customerGetContracts()` requiere de `$snid`.
+
+### Mejorar la dependencia de `PSR-3`
+
+Ahora se permite compatibilidad del paquete `psr/log` con las versiones `^1.1`, `^2.0` o `^3.0`.
+
+### Mejorar la dependencia de `symfony/dotenv`
+
+Se permite la compatibilidad de desarrollo de la librería `symfony/dotenv` con `^5.0` o `^6.0`.
+
+### Saltar las pruebas de integración de cancelación que fallen
+
+A menudo el servicio de pruebas del SAT relacionado con cancelaciones presenta fallas.
+Por esto, las pruebas de integración relacionadas con tocar este servicio,
+en lugar de marcarlas como fallidas se marcarán como brincadas.
+
+- `PhpCfdi\Finkok\Tests\Integration\Services\Cancel\CancelServicesTest::testCreateCfdiThenGetSatStatusThenCancelSignatureThenGetReceipt()`.
+- `PhpCfdi\Finkok\Tests\Integration\Services\Cancel\GetRelatedSignatureServiceTest::testConsumeServiceWithRelated()`.
+- `PhpCfdi\Finkok\Tests\Integration\Services\Retentions\CancelSignatureServiceTest::testCancelSignatureRecentlyCreatedDocument()`.
+
+### Pruebas largas tienen duración definida
+
+Las pruebas largas que reintentan varias veces una tarea ahora tienen un límite de tiempo definido en la variable
+de entorno `FINKOK_LONGTEST_TIMEOUT`. Debe ser un valor entero en segundos, el valor si no existe es 30, mínimo 30 y máximo 600.
+
+### Búsqueda de RFC libre en pruebas
+
+Se implementa una búsqueda binaria en un espacio consecutivo de RFC para hacer únicamente 16 búsquedas.
+Anteriormente, se usaba un espacio que podía conducir a muchas más búsquedas y la prueba
+`PhpCfdi\Finkok\Tests\Integration\Services\Registration\AddServiceTest::testConsumeAddServiceWithRandomRfc`
+no era ejecutada a menos que se permitieran pruebas de larga duración.
+
+### Normalización de `composer.json`
+
+Se incluye la herramienta `composer-normalize` para revisar y normalizar el archivo `composer.json`.
+
+### Se integran los cambios previos no liberados
+
+#### 2022-08-08
 
 Corregir el proceso de construcción:
 
 - Se define el tipo de dato `TEntry` para `MicroCatalog<TEntry>` en `AcceptRejectUuidStatus`.
 - Actualizar librerías de desarrollo.
 
-## Unreleased 2022-07-18
+#### 2022-07-18
 
 Corregir el proceso de construcción:
 
 - Corregir `tests/stamp-precfdi-devenv.php` en su inicialización y estilo de código.
 - Actualizar librerías de desarrollo.
 
-## Unreleased 2022-07-04
+#### 2022-07-04
 
 Estos cambios están presentes únicamente en desarrollo, no es necesaria una nueva versión:
 

--- a/docs/ListadoDeServicios.md
+++ b/docs/ListadoDeServicios.md
@@ -64,7 +64,7 @@ Estos servicios son de CFDI de retenciones e información de pagos (RET).
 
 ## Manifiesto de Finkok
 
-- [X] `get_contracts`: Obtiene los textos para ser firmados
+- [X] `get_contracts_snid`: Obtiene los textos para ser firmados
 - [X] `sign_contract`: Envía los textos firmados con la FIEL
 
 ## Servicios que no se implementarán

--- a/docs/PruebasDeIntegracionContinua.md
+++ b/docs/PruebasDeIntegracionContinua.md
@@ -45,7 +45,7 @@ Para desencriptar el archivo de configuración `tests/.env-testing.enc -> tests/
 comando. Esta operación es la que se ejecuta en `functional-test.yml` usando el secreto `secrets.ENV_GPG_SECRET`.
 
 ```shell
-gpg --quiet --batch --yes --decrypt --output decoded tests/.env-testing.enc
+gpg --quiet --batch --yes --decrypt --output - tests/.env-testing.enc
 ```
 
 ### Cobertura de código

--- a/src/QuickFinkok.php
+++ b/src/QuickFinkok.php
@@ -56,7 +56,7 @@ class QuickFinkok
     /**
      * Este método se encarga de realizar el timbrado de XML, una vez que se timbra el XML se guarda en una cola de
      * espera para ser enviado en el mejor momento a los servicios del SAT, por lo que el servicio de timbrado es
-     * mucho mas rápido, y es de uso recomendado en timbrado de alto numero de timbres por segundo.
+     * mucho más rápido, y es de uso recomendado en timbrado de alto número de timbres por segundo.
      *
      * Nota: El CFDI generado puede no estar disponible en los servidores del SAT hasta varios minutos después
      *
@@ -103,7 +103,7 @@ class QuickFinkok
     }
 
     /**
-     * Este método se usa para consultar el estatus de una factura que se quedo pendiente de enviar al SAT debido a una
+     * Este método se usa para consultar el estatus de una factura que se quedó pendiente de enviar al SAT debido a una
      * falla en el sistema del SAT o bien que se envió a través del método Quick_Stamp
      *
      * @param string $uuid
@@ -118,7 +118,7 @@ class QuickFinkok
     }
 
     /**
-     * Este método es el encargado de cancelar uno o varios CFDIs emitidos por medio de los web services de Finkok
+     * Este método es el encargado de cancelar uno o varios CFDI emitidos por medio de los web services de Finkok
      * Durante el proceso no se envía ningún CSD a Finkok y la solicitud firmada es creada usando los datos del CSD
      *
      * @param Credential $credential
@@ -175,11 +175,11 @@ class QuickFinkok
     }
 
     /**
-     * Obtiene una lista de los UUIDs relacionados de un UUID
+     * Obtiene una lista de los UUID relacionados de un UUID
      *
      * @param Credential $credential
      * @param string $uuid
-     * @param RfcRole|null $role si es NULL entonces se usa el rol de emisor
+     * @param RfcRole|null $role Si es NULL entonces se usa el rol de emisor
      * @return Cancel\GetRelatedSignatureResult
      * @see https://wiki.finkok.com/doku.php?id=get_related_signature
      * @see https://wiki.finkok.com/doku.php?id=get_related
@@ -403,16 +403,18 @@ class QuickFinkok
      * @param string $name
      * @param string $address
      * @param string $email
+     * @param string $snid
      * @return Manifest\GetContractsResult
-     * @see https://wiki.finkok.com/doku.php?id=get_contracts
+     * @see https://wiki.finkok.com/doku.php?id=get_contracts_snid
      */
     public function customerGetContracts(
         string $rfc,
         string $name,
         string $address,
-        string $email
+        string $email,
+        string $snid
     ): Manifest\GetContractsResult {
-        $command = new Manifest\GetContractsCommand($rfc, $name, $address, $email);
+        $command = new Manifest\GetContractsCommand($rfc, $name, $address, $email, $snid);
         $service = new Manifest\GetContractsService($this->settings());
         return $service->obtainContracts($command);
     }
@@ -456,7 +458,7 @@ class QuickFinkok
         $rfc = $fiel->rfc();
         $name = $fiel->legalName();
         $signedOn = $signedOn ?? new DateTimeImmutable();
-        $documents = $this->customerGetContracts($rfc, $name, $address, $email);
+        $documents = $this->customerGetContracts($rfc, $name, $address, $email, $snid);
         if (! $documents->success()) {
             return Manifest\SignContractsResult::createFromData(
                 false,
@@ -529,7 +531,7 @@ class QuickFinkok
     }
 
     /**
-     * Este método es el encargado de cancelar un CFDIs de retenciones emitido por medio de los web services de Finkok
+     * Este método es el encargado de cancelar un CFDI de retenciones emitido por medio de los web services de Finkok
      * Durante el proceso no se envía ningún CSD a Finkok y la solicitud firmada es creada usando los datos del CSD
      *
      * @param Credential $credential

--- a/src/Services/Manifest/GetContractsCommand.php
+++ b/src/Services/Manifest/GetContractsCommand.php
@@ -18,12 +18,16 @@ class GetContractsCommand
     /** @var string */
     private $email;
 
-    public function __construct(string $rfc, string $name, string $address, string $email)
+    /** @var string */
+    private $snid;
+
+    public function __construct(string $rfc, string $name, string $address, string $email, string $snid)
     {
         $this->rfc = $rfc;
         $this->name = $name;
         $this->address = $address;
         $this->email = $email;
+        $this->snid = $snid;
     }
 
     public function rfc(): string
@@ -44,5 +48,10 @@ class GetContractsCommand
     public function email(): string
     {
         return $this->email;
+    }
+
+    public function snid(): string
+    {
+        return $this->snid;
     }
 }

--- a/src/Services/Manifest/GetContractsResult.php
+++ b/src/Services/Manifest/GetContractsResult.php
@@ -11,13 +11,13 @@ class GetContractsResult extends AbstractResult
 {
     public function __construct(stdClass $data)
     {
-        parent::__construct($data, 'get_contractsResult');
+        parent::__construct($data, 'get_contracts_snidResult');
     }
 
     public static function createFromData(bool $success, string $contract, string $privacy, string $error): self
     {
         return new self((object) [
-            'get_contractsResult' => (object) [
+            'get_contracts_snidResult' => (object) [
                 'success' => $success,
                 'contract' => base64_encode($contract),
                 'privacy' => base64_encode($privacy),

--- a/src/Services/Manifest/GetContractsService.php
+++ b/src/Services/Manifest/GetContractsService.php
@@ -26,7 +26,8 @@ class GetContractsService
     {
         // this empty string are for ommiting sending username and password
         $soapCaller = $this->settings()->createCallerForService(Services::manifest(), '', '');
-        $rawResponse = $soapCaller->call('get_contracts', [
+        $rawResponse = $soapCaller->call('get_contracts_snid', [
+            'snid' => $command->snid(),
             'taxpayer_id' => $command->rfc(),
             'name' => $command->name(),
             'address' => $command->address(),

--- a/tests/.env-example
+++ b/tests/.env-example
@@ -9,7 +9,7 @@ FINKOK_PASSWORD="the-secret-password"
 # integration account (something like SN99999999)
 FINKOK_SNID="SN99999999"
 
-# if enabled, will search for an RFC XDEL000101XX1 changing date until found one non existent to be created
+# if enabled, will search for a free RFC to test AddService::add()
 FINKOK_REGISTRATION_ADD_CREATE_RANDOM_RFC="1"
 
 # if enabled, will log request and responses on build/test directory

--- a/tests/.env-example
+++ b/tests/.env-example
@@ -14,3 +14,6 @@ FINKOK_REGISTRATION_ADD_CREATE_RANDOM_RFC="1"
 
 # if enabled, will log request and responses on build/test directory
 FINKOK_LOG_CALLS="0"
+
+# time out in seconds to stop retry on long tests
+FINKOK_LONGTEST_TIMEOUT="300"

--- a/tests/.env-testing.enc
+++ b/tests/.env-testing.enc
@@ -1,1 +1,2 @@
-Œ	òÓ™AxxÿÒÀÞ(ea‘/ÿžü¨¬åOÊ›y\—$þðE5Ó{’©q’Ñ[êK&2£L_RÚ´pZù`Ô‚ý;ÇPòõz„£µ‚PnÉ\É,Ü’bs€’®´s¨JWžb“`yG¨&1ên.ø‰ŠQC¸FÖŽÈIc]£6¬þ–s†BÍ>óNŒ´ÞüÉ¯U‚çÖ˜Z[H¸>IG––:›:_›…Îð|ÅâØhnU±»ÑØ!ù•Ÿúßf¡OíjäcN/Gèä$Ë>••›«?O?¨»”ð­/ËÞ³`RuZç2YñQÖ@&PáªK3pÎ¬;ò4ò¾Ýu¥üüJb°ÿêsæ:oZù@þ:˜*ã<éŠ½òÞI·úa‚7|*g¦«3:wÛi‘æÊÅ‚òtV')Î°³‰	µïÊ„{Y,‚Æ;>²ÆVÜô	gp;žsÛãÀµ?öË+AóT©Ë«r]-¡˜,«eaöÈ-ÉŸþv¨>EŸ½5t­¤sÖêiŠ0ª¾‡[±B°±5:‹¨m
+Œ	ÿ1Ü}›“ÒÅÿÒÁeåHc˜!í1	?¬a©|«ÐkBªº÷ºù‰Àñþ)aDŽ8iþíc%ZÀëPn{Òòîn5ô²*i‰Ú{Ã¦¶Ë~ˆkz•%ÿr-ÐÇ6_ì}ypø^ç7ÇþY®×YÄtGìl›*¿Áé7\«{óÙKœâwØGÓ #3SfAŒÕ­”z„¨ñÎ^:Î2éÀìÕú+V­iP—Å7Ò=mäxæ0Æf
+rÉzî5“ÙÐ³¡8kQBÏÈs_0IiaèŒºÐîŸ¸W¾BiòadÊúÝZ&›ÓOÒ¶ÓA´	Ø¤$äí¼ØJÍ–Ä& @E÷VinÁÊ3Õ`œ;µ.ÊÊÁ”Iû²xã\ž§86(¬ñ¯%{\†4"ÓÙ[ô·½¯:_ÚÝ¯¥‘DbÎƒÈwæöA±}[øXâ=¦â90RÎŸÓqÜÞL•âòTi·\¢t3Ëd®z¥4`/9]Ø°ÝÓìß¡ÂuZÖ$¹Ôóºh6ñK°k.ËÕY*«¨ŠvàfU¯²%†MÍîînt¿Ððœí.Í:„¥ t#ØmÒcEÝñéKOsi\'§dmèpçÍÒè9ð!ÿ²1„ç O£Ó

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -104,4 +104,11 @@ abstract class IntegrationTestCase extends TestCase
         }
         return $result;
     }
+
+    /** @phpstan-impure */
+    public function timePlusLongTestTimeOut(): int
+    {
+        $seconds = max(30, min(600, intval($this->getenv('FINKOK_LONGTEST_TIMEOUT') ?: 30)));
+        return time() + $seconds;
+    }
 }

--- a/tests/Integration/Services/Cancel/CancelServicesTest.php
+++ b/tests/Integration/Services/Cancel/CancelServicesTest.php
@@ -36,7 +36,7 @@ final class CancelServicesTest extends IntegrationTestCase
         // evaluate if known response was 205 or 708
         // this is common to happen on testing but not in production since the time
         // elapsed from stamping and cancelling is often more than 2 minutes
-        $repeatUntil = strtotime('now +5 minutes');
+        $repeatUntil = $this->timePlusLongTestTimeOut();
         do {
             // build command on every request
             $command = $this->createCancelSignatureCommandFromDocument(

--- a/tests/Integration/Services/Cancel/CancelServicesTest.php
+++ b/tests/Integration/Services/Cancel/CancelServicesTest.php
@@ -72,7 +72,10 @@ final class CancelServicesTest extends IntegrationTestCase
         } while (true);
 
         if ('205' === $document->documentStatus()) {
-            $this->fail('SAT return 205 EstatusUUID: The CFDI was not received by SAT yet.');
+            $this->markTestSkipped(<<<MESSAGE
+                Unable to test CancelSignatureService::cancelSignature():
+                SAT return 205 EstatusUUID: The CFDI was not received by SAT yet.
+                MESSAGE);
         }
 
         // check result related document

--- a/tests/Integration/Services/Cancel/GetRelatedSignatureServiceTest.php
+++ b/tests/Integration/Services/Cancel/GetRelatedSignatureServiceTest.php
@@ -61,7 +61,7 @@ final class GetRelatedSignatureServiceTest extends IntegrationTestCase
 
         $command = $this->createGetRelatedSignatureCommand($second->uuid());
         $service = $this->createService();
-        $maxtime = strtotime('+10 minutes');
+        $maxtime = strtotime('+5 minutes');
         while (true) {
             $result = $service->getRelatedSignature($command);
             if (1 === $result->parents()->count() && 1 === $result->children()->count()) {
@@ -76,16 +76,22 @@ final class GetRelatedSignatureServiceTest extends IntegrationTestCase
                 '' !== $result->error()
                 && '2001' !== substr($result->error(), 0, 4)
                 && false === strpos($result->error(), '305')
+                && ! preg_match('/UUID: \S+ No Encontrado/', $result->error())
             ) {
                 break;
             }
 
             // try  again
             if (time() > $maxtime) {
-                $this->fail("After 10 minutes consuming GetRelatedSignatureService didn't get related from SAT");
+                $this->markTestSkipped(<<<MESSAGE
+                    Unable to test GetRelatedSignatureService::getRelatedSignature():
+                    Error: {$result->error()}
+                    MESSAGE);
             }
             sleep(5);
         }
+
+        print_r($result);
 
         $this->assertSame($third->uuid(), $result->parents()->first()->uuid());
         $this->assertSame($first->uuid(), $result->children()->first()->uuid());

--- a/tests/Integration/Services/Cancel/GetRelatedSignatureServiceTest.php
+++ b/tests/Integration/Services/Cancel/GetRelatedSignatureServiceTest.php
@@ -61,7 +61,7 @@ final class GetRelatedSignatureServiceTest extends IntegrationTestCase
 
         $command = $this->createGetRelatedSignatureCommand($second->uuid());
         $service = $this->createService();
-        $maxtime = strtotime('+5 minutes');
+        $maxtime = $this->timePlusLongTestTimeOut();
         while (true) {
             $result = $service->getRelatedSignature($command);
             if (1 === $result->parents()->count() && 1 === $result->children()->count()) {

--- a/tests/Integration/Services/Manifest/GetContractsServiceTest.php
+++ b/tests/Integration/Services/Manifest/GetContractsServiceTest.php
@@ -22,7 +22,8 @@ final class GetContractsServiceTest extends IntegrationTestCase
             'EKU9003173C9',
             'Empresa Conocida SA de CV',
             'Cuauhtémoc #123, Colonia Centro, Villahermosa, Tabasco. CP 86000',
-            'legal@empresa-conocida.mx'
+            'legal@empresa-conocida.mx',
+            $this->getenv('FINKOK_SNID')
         );
 
         $service = $this->createService();
@@ -43,5 +44,6 @@ final class GetContractsServiceTest extends IntegrationTestCase
         // on the new manifest with Quadrum it does not include email or address
         // $this->assertStringContainsString($command->email(), $contract);
         // $this->assertStringContainsString($command->address(), $contract);
+        // $this->assertStringContainsString($command->snid(), $contract);
     }
 }

--- a/tests/Integration/Services/Manifest/SignContractsServiceTest.php
+++ b/tests/Integration/Services/Manifest/SignContractsServiceTest.php
@@ -27,7 +27,8 @@ final class SignContractsServiceTest extends IntegrationTestCase
             $rfc,
             'Empresa Conocida SA de CV',
             'Cuauhtémoc #123, Colonia Centro, Villahermosa, Tabasco. CP 86000',
-            'legal@empresa-conocida.mx'
+            'legal@empresa-conocida.mx',
+            $this->getenv('FINKOK_SNID')
         );
 
         $srvGetContracts = new GetContractsService($settings);

--- a/tests/Integration/Services/Registration/README.md
+++ b/tests/Integration/Services/Registration/README.md
@@ -11,7 +11,8 @@ creará un nuevo registro que no hay forma de limpiar.
 Por este motivo, el test de creación es siempre omitido. Lo puede reactivar estableciendo la
 variable de entorno FINKOK_REGISTRATION_ADD_CREATE_RANDOM_RFC a "1".
 
-El test implementado busca uno a uno un RFC con la forma XDEL000101XX1.
+El test implementado busca un RFC el prefijo `XDEL`.
+Además, se usa el RFC `XDEL000101XX1` para diferentes pruebas y se espera que exista.
 Este RFC está definido en `RegistrationIntegrationTestCase::CUSTOMER_RFC`.
 
 Después puedes solicitar a Finkok que se eliminen estos RFC vía correo electrónico, porque sí.

--- a/tests/Integration/Services/Retentions/CancelSignatureServiceTest.php
+++ b/tests/Integration/Services/Retentions/CancelSignatureServiceTest.php
@@ -41,7 +41,7 @@ final class CancelSignatureServiceTest extends RetentionsTestCase
             throw new RuntimeException('Cannot create a CFDI RET to cancel');
         }
 
-        $maxtime = strtotime('+5 minutes');
+        $maxtime = $this->timePlusLongTestTimeOut();
         while (true) {
             $result = $this->quickFinkok->retentionCancel(
                 $this->createCsdCredential(),
@@ -61,7 +61,7 @@ final class CancelSignatureServiceTest extends RetentionsTestCase
             if (time() > $maxtime) {
                 $this->markTestSkipped(<<<MESSAGE
                     Unable to test QuickFinkok::retentionCancel():
-                    StatusCode: {$result->statusCode()}, DocumentStatus {$document->documentStatus()}
+                    StatusCode: [{$result->statusCode()}], DocumentStatus [{$document->documentStatus()}]
                     MESSAGE);
             }
             sleep(5);

--- a/tests/Integration/Services/Retentions/CancelSignatureServiceTest.php
+++ b/tests/Integration/Services/Retentions/CancelSignatureServiceTest.php
@@ -59,7 +59,10 @@ final class CancelSignatureServiceTest extends RetentionsTestCase
 
             // try again
             if (time() > $maxtime) {
-                $this->fail('Cannot get a valid response to cancel a retention CFDI');
+                $this->markTestSkipped(<<<MESSAGE
+                    Unable to test QuickFinkok::retentionCancel():
+                    StatusCode: {$result->statusCode()}, DocumentStatus {$document->documentStatus()}
+                    MESSAGE);
             }
             sleep(5);
         }

--- a/tests/LoggerPrinter.php
+++ b/tests/LoggerPrinter.php
@@ -17,12 +17,16 @@ final class LoggerPrinter extends AbstractLogger implements LoggerInterface
         $this->outputFile = $outputFile;
     }
 
-    /** @inheritDoc */
+    /**
+     * @inheritDoc
+     * @param string|\Stringable $message
+     * @param mixed[] $context
+     */
     public function log($level, $message, array $context = []): void
     {
         file_put_contents(
             $this->outputFile,
-            PHP_EOL . print_r(json_decode($message), true),
+            PHP_EOL . print_r(json_decode(strval($message)), true),
             FILE_APPEND
         );
     }

--- a/tests/Unit/QuickFinkokTest.php
+++ b/tests/Unit/QuickFinkokTest.php
@@ -396,13 +396,14 @@ final class QuickFinkokTest extends TestCase
         $rawData = json_decode($this->fileContentPath('manifest-getcontracts-response.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
 
-        $result = $finkok->customerGetContracts('x-rfc', 'x-name', 'x-address', 'x-email');
+        $result = $finkok->customerGetContracts('x-rfc', 'x-name', 'x-address', 'x-email', 'x-snid');
 
-        $this->performTestOnLatestCall('get_contracts', [
+        $this->performTestOnLatestCall('get_contracts_snid', [
             'taxpayer_id' => 'x-rfc',
             'name' => 'x-name',
             'address' => 'x-address',
             'email' => 'x-email',
+            'snid' => 'x-snid',
         ]);
         $this->assertEquals($rawData, $result->rawData());
     }

--- a/tests/Unit/Services/Manifest/GetContractsCommandTest.php
+++ b/tests/Unit/Services/Manifest/GetContractsCommandTest.php
@@ -11,10 +11,11 @@ final class GetContractsCommandTest extends TestCase
 {
     public function testCreateCommand(): void
     {
-        $command = new GetContractsCommand('x-rfc', 'x-name', 'x-address', 'x-email');
+        $command = new GetContractsCommand('x-rfc', 'x-name', 'x-address', 'x-email', 'x-snid');
         $this->assertSame('x-rfc', $command->rfc());
         $this->assertSame('x-name', $command->name());
         $this->assertSame('x-address', $command->address());
         $this->assertSame('x-email', $command->email());
+        $this->assertSame('x-snid', $command->snid());
     }
 }

--- a/tests/Unit/Services/Manifest/GetContractsServiceTest.php
+++ b/tests/Unit/Services/Manifest/GetContractsServiceTest.php
@@ -23,12 +23,12 @@ final class GetContractsServiceTest extends TestCase
         $settings = $this->createSettingsFromEnvironment($soapFactory);
         $service = new GetContractsService($settings);
 
-        $command = new GetContractsCommand('x-rfc', 'x-name', 'x-address', 'x-email');
+        $command = new GetContractsCommand('x-rfc', 'x-name', 'x-address', 'x-email', 'x-snid');
         $result = $service->obtainContracts($command);
         $this->assertSame('predefined-contract', $result->contract());
 
         $caller = $soapFactory->latestSoapCaller;
-        $this->assertSame('get_contracts', $caller->latestCallMethodName);
+        $this->assertSame('get_contracts_snid', $caller->latestCallMethodName);
         $this->assertArrayHasKey('taxpayer_id', $caller->latestCallParameters);
         $this->assertSame($command->rfc(), $caller->latestCallParameters['taxpayer_id']);
         $this->assertArrayHasKey('name', $caller->latestCallParameters);
@@ -37,5 +37,7 @@ final class GetContractsServiceTest extends TestCase
         $this->assertSame($command->address(), $caller->latestCallParameters['address']);
         $this->assertArrayHasKey('email', $caller->latestCallParameters);
         $this->assertSame($command->email(), $caller->latestCallParameters['email']);
+        $this->assertArrayHasKey('snid', $caller->latestCallParameters);
+        $this->assertSame($command->snid(), $caller->latestCallParameters['snid']);
     }
 }

--- a/tests/_files/manifest-getcontracts-response.json
+++ b/tests/_files/manifest-getcontracts-response.json
@@ -1,5 +1,5 @@
 {
-  "get_contractsResult": {
+  "get_contracts_snidResult": {
     "success": true,
     "contract": "cHJlZGVmaW5lZC1jb250cmFjdA==",
     "privacy": "cHJlZGVmaW5lZC1wcml2YWN5",


### PR DESCRIPTION
### Implementación del método `get_contracts_sndi`

Se utiliza el nuevo método `get_contracts_sndi` en lugar del obsoleto `get_contracts`.
Esto lleva a que la clase `PhpCfdi\Finkok\Services\Manifest\GetContractsCommand` ahora requiere de `$snid`.
Igualmente, `PhpCfdi\Finkok\QuickFinkok#customerGetContracts()` requiere de `$snid`.

### Mejorar la dependencia de `PSR-3`

Ahora se permite compatibilidad del paquete `psr/log` con las versiones `^1.1`, `^2.0` o `^3.0`.

### Mejorar la dependencia de `symfony/dotenv`

Se permite la compatibilidad de desarrollo de la librería `symfony/dotenv` con `^5.0` o `^6.0`.

### Saltar las pruebas de integración de cancelación que fallen

A menudo el servicio de pruebas del SAT relacionado con cancelaciones presenta fallas.
Por esto, las pruebas de integración relacionadas con tocar este servicio, en lugar de marcarlas como fallidas se marcarán como brincadas.

- `PhpCfdi\Finkok\Tests\Integration\Services\Cancel\CancelServicesTest::testCreateCfdiThenGetSatStatusThenCancelSignatureThenGetReceipt()`.
- `PhpCfdi\Finkok\Tests\Integration\Services\Cancel\GetRelatedSignatureServiceTest::testConsumeServiceWithRelated()`.
- `PhpCfdi\Finkok\Tests\Integration\Services\Retentions\CancelSignatureServiceTest::testCancelSignatureRecentlyCreatedDocument()`.

### Pruebas largas tienen duración definida

Las pruebas largas que reintentan varias veces una tarea ahora tienen un límite de tiempo definido en la variable de entorno `FINKOK_LONGTEST_TIMEOUT`. Debe ser un valor entero en segundos, el valor si no existe es 30, mínimo 30 y máximo 600.

### Búsqueda de RFC libre en pruebas

Se implementa una búsqueda binaria en un espacio consecutivo de RFC para hacer únicamente 16 búsquedas. Anteriormente, se usaba un espacio que podía conducir a muchas más búsquedas y la prueba `PhpCfdi\Finkok\Tests\Integration\Services\Registration\AddServiceTest::testConsumeAddServiceWithRandomRfc` no era ejecutada a menos que se permitieran pruebas de larga duración.

### Normalización de `composer.json`

Se incluye la herramienta `composer-normalize` para revisar y normalizar el archivo `composer.json`.