### PR TITLE
Corregir el código para que el proceso de integración contínua no falle

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -2,7 +2,7 @@
 <phive xmlns="https://phar.io/phive">
   <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.9.5" installed="3.9.5" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="^1.8.2" installed="1.8.2" location="./tools/phpstan" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.11.0" installed="3.11.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpstan" version="^1.8.4" installed="1.8.4" location="./tools/phpstan" copy="false"/>
   <phar name="composer-normalize" version="^2.28.3" installed="2.28.3" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -29,7 +29,7 @@ return (new PhpCsFixer\Config())
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
         'phpdoc_scalar' => true,
-        'no_trailing_comma_in_singleline_array' => true,
+        'no_trailing_comma_in_singleline' => true,
         'single_quote' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_unused_imports' => true,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,9 +4,9 @@ Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor e
 
 ## Versión 0.5.0 2022-08-12
 
-### Implementación del método `get_contracts_sndi`
+### Implementación del método `get_contracts_snid`
 
-Se utiliza el nuevo método `get_contracts_sndi` en lugar del obsoleto `get_contracts`.
+Se utiliza el nuevo método `get_contracts_snid` en lugar del obsoleto `get_contracts`.
 Esto lleva a que la clase `PhpCfdi\Finkok\Services\Manifest\GetContractsCommand` ahora requiere de `$snid`.
 Igualmente, `PhpCfdi\Finkok\QuickFinkok#customerGetContracts()` requiere de `$snid`.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor el control de versiones.
 
+## Cambios no liberados
+
+Estos cambios se aplican y se publican, pero aún no son parte de una versión liberada.
+
+### 2022-09-05 
+
+El proceso de integración contínua con las herramientas de desarrollo actualizadas falló,
+por lo que se aplicaron los siguientes cambios:
+
+- Se eliminan las anotaciones de definición de tipos de datos para la constante `Finkok::SERVICES_MAP`.
+- En la configuración de la herramienta `php-cs-fixer` se sustituye la regla `no_trailing_comma_in_singleline_array` 
+  por la regla `no_trailing_comma_in_singleline`.
+- Se corrige el texto `get_contracts_sndi` a `get_contracts_snid`.
+- Se actualizan las herramientas de desarrollo.
+
 ## Versión 0.5.0 2022-08-12
 
 ### Implementación del método `get_contracts_snid`

--- a/src/Finkok.php
+++ b/src/Finkok.php
@@ -41,7 +41,6 @@ use PhpCfdi\Finkok\Services\Utilities;
  */
 class Finkok
 {
-    /** @var array<string, array{0: class-string, 1: class-string, 2?: string}> */
     protected const SERVICES_MAP = [
         'stamp' => [Stamping\StampService::class, Stamping\StampingCommand::class],
         'quickstamp' => [Stamping\QuickStampService::class, Stamping\StampingCommand::class],
@@ -120,7 +119,6 @@ class Finkok
      */
     protected function checkCommand(string $method, $command): ?object
     {
-        /** @var class-string|string $expected */
         $expected = static::SERVICES_MAP[$method][1];
         if ('' === $expected) {
             return null;


### PR DESCRIPTION
El proceso de integración contínua con las herramientas de desarrollo actualizadas falló, por lo que se aplicaron los siguientes cambios:

- Se eliminan las anotaciones de definición de tipos de datos para la constante `Finkok::SERVICES_MAP`.
- En la configuración de la herramienta `php-cs-fixer` se sustituye la regla `no_trailing_comma_in_singleline_array` por la regla `no_trailing_comma_in_singleline`.
- Se corrige el texto `get_contracts_sndi` a `get_contracts_snid`.
- Se actualizan las herramientas de desarrollo.
