### PR TITLE
Mantenimiento 2022-12-20 (v0.5.1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2 # see https://github.com/marketplace/actions/setup-php-action
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: composer-normalize
         env:
@@ -35,7 +35,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2 # see https://github.com/marketplace/actions/setup-php-action
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -67,9 +67,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2 # see https://github.com/marketplace/actions/setup-php-action
+        uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2, phpstan
           extensions: soap
@@ -77,7 +77,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
@@ -94,7 +94,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -109,7 +109,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [ 'main' ]
 
+# Actions
+# shivammathur/setup-php@v2 https://github.com/marketplace/actions/setup-php-action
+# sudo-bot/action-scrutinizer@latest https://github.com/marketplace/actions/action-scrutinizer
+
 jobs:
   functional-tests:
     name: Functional tests
@@ -14,12 +18,13 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # required for sudo-bot/action-scrutinizer
 
-      # see https://github.com/marketplace/actions/setup-php-action
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           extensions: soap
           coverage: xdebug
           tools: composer:v2
@@ -28,7 +33,7 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
         uses: actions/cache@v3
@@ -51,7 +56,6 @@ jobs:
       - name: Run integration tests with code coverage
         run: vendor/bin/phpunit --testdox --verbose --exclude-group large --coverage-clover=build/coverage-clover.xml
 
-      # see https://github.com/marketplace/actions/action-scrutinizer
       - name: Upload code coverage to scrutinizer
         uses: sudo-bot/action-scrutinizer@latest
         with:

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -2,7 +2,7 @@
 <phive xmlns="https://phar.io/phive">
   <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.11.0" installed="3.11.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="^1.8.4" installed="1.8.4" location="./tools/phpstan" copy="false"/>
-  <phar name="composer-normalize" version="^2.28.3" installed="2.28.3" location="./tools/composer-normalize" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.13.1" installed="3.13.1" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpstan" version="^1.9.4" installed="1.9.4" location="./tools/phpstan" copy="false"/>
+  <phar name="composer-normalize" version="^2.29.3" installed="2.29.0" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -11,20 +11,19 @@ declare(strict_types=1);
 
 return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
-    ->setCacheFile(__DIR__ . '/build/php_cs.cache')
+    ->setCacheFile(__DIR__ . '/build/php-cs-fixer.cache')
     ->setRules([
         '@PSR12' => true,
         '@PSR12:risky' => true,
         '@PHP71Migration:risky' => true,
         '@PHP73Migration' => true,
-        // PSR12 (remove when php-cs-fixer reaches ^3.1.1)
-        'class_definition' => ['space_before_parenthesis' => true],
         // symfony
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
+        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
@@ -37,16 +36,18 @@ return (new PhpCsFixer\Config())
         'standardize_not_equals' => true,
         'concat_space' => ['spacing' => 'one'],
         'linebreak_after_opening_tag' => true,
+        'fully_qualified_strict_types' => true,
         // symfony:risky
         'no_alias_functions' => true,
         'self_accessor' => true,
         // contrib
         'not_operator_with_successor_space' => true,
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const']], // @PSR12 sort_algorithm: none
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->in(__DIR__)
             ->append([__FILE__])
-            ->exclude(['vendor', 'tools', 'build'])
+            ->exclude(['vendor', 'tools', 'build']),
     )
 ;

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [badge-source]: https://img.shields.io/badge/source-phpcfdi/finkok-blue?style=flat-square
 [badge-release]: https://img.shields.io/github/release/phpcfdi/finkok?style=flat-square
 [badge-license]: https://img.shields.io/github/license/phpcfdi/finkok?style=flat-square
-[badge-build]: https://img.shields.io/github/workflow/status/phpcfdi/finkok/build/main?style=flat-square
+[badge-build]: https://img.shields.io/github/actions/workflow/status/phpcfdi/finkok/build.yml?branch=main&style=flat-square
 [badge-quality]: https://img.shields.io/scrutinizer/g/phpcfdi/finkok/main?style=flat-square
 [badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/phpcfdi/finkok/main?style=flat-square
 [badge-downloads]: https://img.shields.io/packagist/dt/phpcfdi/finkok?style=flat-square

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Durante el proceso de implementación he creado diversas notas y documentos:
     - [X] [El acuse de cancelación entregado al cancelar y al solicitar el acuse no coinciden](docs/issues/AcuseCancelacionNoCoincidente.md)
     - [X] [Error de cancelación de retenciones 1308 - Certificado revocado o caduco](docs/issues/CancelacionRetencionesError1308.md)
     - [X] [El valor `CodEstatus` está ausente en la cancelación de CFDI de Retenciones](docs/issues/CancelacionRetencionesCodEstatus.md)
+    - [ ] [El método `Registration#Get` con `taxpayer_id` vacío no devuelve el listado de clientes](docs/issues/RegistrationGetNoList.md)
 
 ## Compatibilidad
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "eclipxe/micro-catalog": "^0.1.0",
         "phpcfdi/cfdi-expresiones": "^3.2",
         "phpcfdi/credentials": "^1.0.1",
-        "phpcfdi/xml-cancelacion": "^2.0.1",
+        "phpcfdi/xml-cancelacion": "^2.0.2",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "robrichards/xmlseclibs": "^3.0.4"
     },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,10 @@ Se actualiza `phpcfdi/xml-cancelacion` a la versión `^2.0.2`.
 Esta actualización remueve el atributo vacío `FolioSustitucion` en la solicitud de cancelación firmada.
 Se aplican los cambios necesarios en los tests.
 
+### Cambios de entorno de desarrollo
+
+- Se actualizan las herramientas de desarrollo.
+
 ### Se integran los cambios previos no liberados
 
 #### 2022-09-05

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,11 @@ Se aplican los cambios necesarios en los tests.
 
 - Se actualizan las herramientas de desarrollo.
 - Se actualiza la herramienta configuración de `php-cs-fixer` a la última usada por los otros proyectos de PhpCfdi.
+- Se actualizan los flujos de trabajo de GitHub:
+  - Se agrega PHP 8.2 a la matriz de pruebas.
+  - Se cambia el uso de `::set-output` por `$GITHUB_OUTPUT`.
+  - Los trabajos corren en PHP 8.2, excepto por `php-cs-fixer`.
+  - Se agrega `fetch-depth: 0` cuando se sube la cobertura de código a Scrutinizer-CI.
 
 ### Se integran los cambios previos no liberados
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,9 @@ Estos cambios se aplican y se publican, pero aún no son parte de una versión l
 
 Se actualiza `phpcfdi/xml-cancelacion` a la versión `^2.0.2`.
 Esta actualización remueve el atributo vacío `FolioSustitucion` en la solicitud de cancelación firmada.
-Se aplican los cambios necesarios en los tests.
+Se aplican los cambios necesarios en las pruebas.
+
+Se documenta el error de funcionamiento en Finkok en el método `Registration#Get`.
 
 ### Cambios de entorno de desarrollo
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ Se aplican los cambios necesarios en los tests.
 ### Cambios de entorno de desarrollo
 
 - Se actualizan las herramientas de desarrollo.
+- Se actualiza la herramienta configuración de `php-cs-fixer` a la última usada por los otros proyectos de PhpCfdi.
 
 ### Se integran los cambios previos no liberados
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,15 @@ Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor e
 
 Estos cambios se aplican y se publican, pero aún no son parte de una versión liberada.
 
-### 2022-09-05 
+## Versión 0.5.1 2022-12-19
+
+Se actualiza `phpcfdi/xml-cancelacion` a la versión `^2.0.2`.
+Esta actualización remueve el atributo vacío `FolioSustitucion` en la solicitud de cancelación firmada.
+Se aplican los cambios necesarios en los tests.
+
+### Se integran los cambios previos no liberados
+
+#### 2022-09-05
 
 El proceso de integración contínua con las herramientas de desarrollo actualizadas falló,
 por lo que se aplicaron los siguientes cambios:

--- a/docs/issues/RegistrationGetNoList.md
+++ b/docs/issues/RegistrationGetNoList.md
@@ -1,0 +1,57 @@
+# El método `Registration#Get` con `taxpayer_id` vacío no devuelve el listado de clientes
+
+## Descripción
+
+El método `Registration#Get` debería devolver todos los clientes relacionados con la cuenta
+cuando no se envía el parámetro `taxpayer_id`.
+
+Así está documentado en el webservice:
+
+- https://facturacion.finkok.com/servicios/soap/registration.wsdl
+
+> This function lists all the user of the account if no taxpayer_id is passed
+> otherwise will return the taxpayer_id and status of the given user.
+
+```xml
+<wsdl:operation name="get" parameterOrder="get">
+    <wsdl:documentation>
+      This function lists all the user of the account if no taxpayer_id is passed otherwise will return the taxpayer_id and status of the given user.
+    </wsdl:documentation>
+    <wsdl:input name="get" message="tns:get"/>
+    <wsdl:output name="getResponse" message="tns:getResponse"/>
+</wsdl:operation>
+```
+
+Y en la documentación:
+
+- <https://wiki.finkok.com/doku.php?id=get>
+
+> Este método tiene como finalidad la de otorgar al socio de negocios un listado
+> o el status del RFC Emisor que esté ingresando y tenga registrado en su cuenta.
+
+Al correr pruebas de integración, hemos notado que este ya no es el caso, y en su lugar, en vez de devolver el listado,
+devuelve el mensaje `RFC Invalido` (así, sin acento). Anteriormente, sí devolvía el listado de clientes.
+
+## Reporte
+
+Se reportó a Finkok en el [ticket #66516](https://support.finkok.com/support/tickets/66516), sin embargo,
+la respuesta fue que —efectivamente— este método se comportaba de la manera documentada y esperada en el
+entorno de pruebas, pero que el cambio nunca llegó a producción. Actualmente, no devuelve el listado de
+clientes ni en el entorno de pruebas ni en producción.
+
+También comentan que se agregará otro método diferente para poder obtener el listado, sin embargo,
+todavía no tienen fecha estimada para la implementación.
+
+Finkok debería considerar esto como un fallo en su aplicación, no como una nueva funcionalidad a agregar.
+Y, consecuentemente, darle prioridad alta para repararlo.
+
+## Solución
+
+No existe solución. La recomendación que te hacemos desde esta librería es:
+
+1. Levanta un ticket comentando que necesitas este método funcionando.
+2. Lleva un control de tus clientes y usa la interfaz web para corroborar que estás en sincronía.
+
+## Actualizaciones
+
+2022-12-20: Se reportó y documentó el problema.

--- a/tests/Integration/Services/Registration/ObtainServiceTest.php
+++ b/tests/Integration/Services/Registration/ObtainServiceTest.php
@@ -45,12 +45,10 @@ final class ObtainServiceTest extends RegistrationIntegrationTestCase
         $service = $this->createService();
         $result = $service->obtain(new ObtainCommand());
         if ('RFC Invalido' === $result->message()) {
-            $this->markTestSkipped(
-                <<< EOM
+            $this->markTestSkipped(<<< MESSAGE
                 Finkok does not have implemented the list of customers.
                 See https://support.finkok.com/support/tickets/66516
-                EOM
-            );
+                MESSAGE);
         }
 
         $this->assertSame('', $result->message());

--- a/tests/Integration/Services/Registration/ObtainServiceTest.php
+++ b/tests/Integration/Services/Registration/ObtainServiceTest.php
@@ -44,6 +44,14 @@ final class ObtainServiceTest extends RegistrationIntegrationTestCase
     {
         $service = $this->createService();
         $result = $service->obtain(new ObtainCommand());
+        if ('RFC Invalido' === $result->message()) {
+            $this->markTestSkipped(
+                <<< EOM
+                Finkok does not have implemented the list of customers.
+                See https://support.finkok.com/support/tickets/66516
+                EOM
+            );
+        }
 
         $this->assertSame('', $result->message());
         $this->assertGreaterThanOrEqual(1, count($result->customers()));

--- a/tests/_files/cancel-cancelsignature-format.xml
+++ b/tests/_files/cancel-cancelsignature-format.xml
@@ -2,7 +2,7 @@
 <Cancelacion xmlns="http://cancelacfd.sat.gob.mx" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" RfcEmisor="EKU9003173C9" Fecha="2022-01-06T17:49:12">
     <Folios>
-        <Folio UUID="62B00C5E-4187-4336-B569-44E0030DC729" Motivo="02" FolioSustitucion=""></Folio>
+        <Folio UUID="62B00C5E-4187-4336-B569-44E0030DC729" Motivo="02"></Folio>
     </Folios>
     <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
         <SignedInfo>
@@ -13,10 +13,10 @@
                     <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
                 </Transforms>
                 <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
-                <DigestValue>C5CrlWmW2k+LRbwIz2JTydPW2+g=</DigestValue>
+                <DigestValue>28wlg0suJ57t4P4P+LshbcH5PYE=</DigestValue>
             </Reference>
         </SignedInfo>
-        <SignatureValue>Kxm+BjKx10C/G3c8W8IItAXgdxKP1hmBf2F4DnVcPLTKNfvRu/E29NG2PXDcXGUauAOLi13+7BT2ovURHQKNsjErmAD5Ya09gkUHNstg8ja6K3O5haTNWSIGGf1ZGi1fY8pZ/VSL32L1BnJsu3d81tnxnpriSWkqSQHG2xcll9L2qxdjxlhPfllL1D9nF1TrCv6QCGzgmnRXs6sgUz7Zb2nZaJzPPnausyktEs56LnQr+dpgGs12G8X4NyqFVo8byNA5/fSwF6WLl7RN4p9fKI1WGZg93yHLG6R1fZ+80N0vebNmRDJCHnTrO2aLOn1dkneCqBExOzj8hJMWljzWGQ==</SignatureValue>
+        <SignatureValue>h1USGSs4ziIxiWowgp4KItvI/4HlneSyAP+4wSK59NK2ym4Qlyxmtj9O7YCb6Sr6iNhPWBX4pYcNEOpS2rSmpADdhUlxHxxed5XUdfxGViBtSF8y8hahuTiImdE+d41BiXdu2ml/GUbXhDjbWImDYgAevg5tQILJ02PuMNZYWE2WNUGbvwiT9239+vmKmxYtrZYTBaNfI5ESd3Bf6mOeu8qEGCfV0V8O8iBzrkxCuKbfkowe6a/CROcybPJ/WiwXNHP2pPS7FCvQScdObtC89UOCvafgIDEziWREU4SFMydApyhG9Hk/hB9MbsrDdAS/3OjZTNjfRCPV5bo2zAngHg==</SignatureValue>
         <KeyInfo>
             <X509Data>
                 <X509IssuerSerial>


### PR DESCRIPTION
Se actualiza `phpcfdi/xml-cancelacion` a la versión `^2.0.2`. Esta actualización remueve el atributo vacío `FolioSustitucion` en la solicitud de cancelación firmada. Se aplican los cambios necesarios en las pruebas.

Se documenta el error de funcionamiento en Finkok en el método `Registration#Get`.

Cambios de entorno de desarrollo

- Se actualizan las herramientas de desarrollo.
- Se actualiza la herramienta configuración de `php-cs-fixer` a la última usada por los otros proyectos de PhpCfdi.
- Se actualizan los flujos de trabajo de GitHub:
  - Se agrega PHP 8.2 a la matriz de pruebas.
  - Se cambia el uso de `::set-output` por `$GITHUB_OUTPUT`.
  - Los trabajos corren en PHP 8.2, excepto por `php-cs-fixer`.
  - Se agrega `fetch-depth: 0` cuando se sube la cobertura de código a Scrutinizer-CI.