### PR TITLE
Implementación de `Registration#Customers` (version 0.5.2)

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -2,7 +2,7 @@
 <phive xmlns="https://phar.io/phive">
   <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.13.1" installed="3.13.1" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="^1.9.4" installed="1.9.4" location="./tools/phpstan" copy="false"/>
-  <phar name="composer-normalize" version="^2.29.3" installed="2.29.0" location="./tools/composer-normalize" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.13.2" installed="3.13.2" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpstan" version="^1.9.6" installed="1.9.6" location="./tools/phpstan" copy="false"/>
+  <phar name="composer-normalize" version="^2.29.0" installed="2.29.0" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 - 2022 PhpCfdi https://www.phpcfdi.com
+Copyright (c) 2019 - 2023 PhpCfdi https://www.phpcfdi.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Obtener reportes de consumo de crédito y manejo de clientes:
 * `registrationEdit(Registration\EditCommand $command): Registration\EditResult`
 * `registrationSwitch(Registration\SwitchCommand $command): Registration\SwitchResult`
 * `registrationObtain(Registration\ObtainCommand $command): Registration\ObtainResult`
+* `registrationCustomers(Registration\ObtainCustomersCommand $command): Registration\ObtainCustomersResult`
 
 ### Manifiestos y contrato
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,23 @@ Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor e
 
 Estos cambios se aplican y se publican, pero aún no son parte de una versión liberada.
 
+## Versión 0.5.2 2023-01-03
+
+Se reportó que el webservice `Registration#Get` no estaba aceptando un RFC vacío para devolver el listado
+de clientes. La respuesta de Finkok fue implementar un nuevo método `Registration#Customers` que devuelve
+el listado de clientes paginado. El método `Registration#Get` ya no permitirá devolver un listado de clientes. 
+
+Se agregan los métodos `Finkok::registrationCustomers` y `QuickFinkok::customersObtainAll`
+para consumir `Registration#Customers`.
+
+El método `Finkok::registrationCustomers(ObtainCustomersCommand $command): ObtainCustomersResult` devuelve
+el resultado de una sola página, con toda la información: mensaje e información de paginado.
+
+El método `QuickFinkok::customersObtainAll` devuelve solamente el listado de clientes consumiendo
+todas las páginas necesarias.
+
+Se cambió el año en el archivo de licencia, ¡Feliz 2023!.
+
 ## Versión 0.5.1 2022-12-19
 
 Se actualiza `phpcfdi/xml-cancelacion` a la versión `^2.0.2`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6,14 +6,14 @@
 - Investigar cómo validar firma en acuses y respuestas del SAT
 
 - Crear un namespace común porque hay clases que están interrelacionadas entre el estampado y cancelación
-  de cfdi y de retenciones. Así como las clases abstractas de colecciones y resultados. 
-  Esto creará una incompatilidad con versiones previas.
+  de CFDI y de retenciones. Así como las clases abstractas de colecciones y resultados. 
+  Esto creará una incompatibilidad con versiones previas.
 
-- Agregar la integración de CFDI de retenciones y pagos
+- Agregar la integración de CFDI de retenciones y pagos.
 
 - Poder transformar un objeto de tipo `GetSatStatusResult` a `PhpCfdi\SatEstadoCfdi\CfdiStatus`.
 
-- Los reportes que devuelven una cuenta deberían retornar un entero
+- Los reportes que devuelven una cuenta deberían retornar un entero.
 
 - La forma en que están hechos los objetos result es mezclada, algunas propiedades las obtiene cuando se solicitan
   y otras propiedades las obtiene en la creación del objeto. El problema es que se guarda la referencia al objeto
@@ -24,11 +24,11 @@
   La segunda opción genera mutabilidad al poderse manipular el input. 
   La tercera opción es no permitir manipular en input una vez que está dentro del resultado.
 
-- Fortalecer los comandos como DownloadXml (get_xml) que el tipo solo puede ser I - CFDI o R - Retenciones
+- Fortalecer los comandos como DownloadXml (get_xml) que el tipo solo puede ser I - CFDI o R - Retenciones.
 
-- Poder configurar en Travis CI la ejecución de tests de integración
+- Poder configurar en Travis CI la ejecución de tests de integración.
 
-- AcceptRejectSigner debería permitir aceptar y/o rechazar más de 1 solo UUID a la vez
+- AcceptRejectSigner debería permitir aceptar y/o rechazar más de 1 solo UUID a la vez.
 
 - Agregar un caso para hacer una prueba positiva de AcceptRejectSignatureService. 
   Para hacer esta prueba se requieren 2 RFC (A y B), en este momento solo tenemos 1. 
@@ -43,6 +43,9 @@
   error al crear el endpoint, el error saldría a la luz en pruebas de integración pero no en pruebas unitarias. 
   Se puede agregar un código como el siguiente (en `...\Tests\Unit\Services\Retentions\CancelSignatureServiceTest`):
   `$this->assertStringEndsWith(Services::retentions()->value(), $soapFactory->latestWsdlLocation);`
+
+- En el entorno de pruebas, en el objeto `FakeSoapFactory` permitir una cola de respuestas para simular el consumo
+  de varias páginas del servicio `Registration#Customers`.
 
 ## Documentación
 

--- a/docs/issues/RegistrationGetNoList.md
+++ b/docs/issues/RegistrationGetNoList.md
@@ -45,13 +45,40 @@ todavía no tienen fecha estimada para la implementación.
 Finkok debería considerar esto como un fallo en su aplicación, no como una nueva funcionalidad a agregar.
 Y, consecuentemente, darle prioridad alta para repararlo.
 
+### Reporte 2022-01-03
+
+A pesar de la implementación del método `Registration#Customers`, el método `Registration#Get` sigue retornando
+un conjunto de `ResellerUser`, cuando debería de regresar cero o uno. Asimismo, se cambió la documentación
+para que ni diga que devuelve un listado de clientes.
+
+Se desconoce la fecha de pase a producción de la solución.
+
 ## Solución
 
-No existe solución. La recomendación que te hacemos desde esta librería es:
+Finkok implementó el método `Registration#Customers` con el que se puede obtener el listado de clientes.
 
-1. Levanta un ticket comentando que necesitas este método funcionando.
-2. Lleva un control de tus clientes y usa la interfaz web para corroborar que estás en sincronía.
+Al 2022-01-03 se hizo la implementación del método `Registration#Customers`.
+
+### Implementación
+
+Este método devuelve un **listado paginado** —cosa que no habían hecho en ningún otro método—
+y se implementa de dos formas diferentes:
+
+#### `QuickFinkok::customersObtainAll(): Customers`
+
+Al llamarlo consume tantas páginas sea necesario y retorna el listado completo de clientes en el objeto `Customers`.
+No contiene los datos originales de las consultas, a diferencia de la mayoría de los valores retornados.
+
+#### `Finkok::registrationCustomers(ObtainCustomersCommand $command): ObtainCustomersResult`
+
+Al llamarlo consume el servicio y obtiene la página especificada.
+Este método sí contiene un objeto `ObtainCustomersResult` con toda la respuesta de la consulta.
+Solo devuelve los datos de la consulta especificada.
 
 ## Actualizaciones
 
 2022-12-20: Se reportó y documentó el problema.
+
+2022-12-31: Se agregó el método `Registration#Customers`.
+
+2022-01-03: Se implementó el consumo del método `Registration#Customers`.

--- a/src/Finkok.php
+++ b/src/Finkok.php
@@ -38,6 +38,7 @@ use PhpCfdi\Finkok\Services\Utilities;
  * @method Registration\SwitchResult registrationSwitch(Registration\SwitchCommand $command)
  * @method Registration\EditResult registrationEdit(Registration\EditCommand $command)
  * @method Registration\ObtainResult registrationObtain(Registration\ObtainCommand $command)
+ * @method Registration\ObtainCustomersResult registrationCustomers(Registration\ObtainCustomersCommand $command)
  */
 class Finkok
 {
@@ -82,6 +83,11 @@ class Finkok
         'registrationSwitch' => [Registration\SwitchService::class, Registration\SwitchCommand::class, 'switch'],
         'registrationEdit' => [Registration\EditService::class, Registration\EditCommand::class, 'edit'],
         'registrationObtain' => [Registration\ObtainService::class, Registration\ObtainCommand::class, 'obtain'],
+        'registrationCustomers' => [
+            Registration\ObtainCustomersService::class,
+            Registration\ObtainCustomersCommand::class,
+            'obtainPage',
+        ],
     ];
 
     /** @var FinkokSettings */

--- a/src/QuickFinkok.php
+++ b/src/QuickFinkok.php
@@ -379,6 +379,19 @@ class QuickFinkok
     }
 
     /**
+     * Obtiene el listado completo de clientes, consultando todas las páginas necesarias.
+     * El resultado es solo la lista de clientes, sin acceso a los resultados de cada una de las consultas.
+     *
+     * @return Registration\Customers
+     * @see https://wiki.finkok.com/doku.php?id=customers
+     */
+    public function customersObtainAll(): Registration\Customers
+    {
+        $service = new Registration\ObtainCustomersService($this->settings());
+        return $service->obtainAll();
+    }
+
+    /**
      * Asignar créditos un cliente que va a timbrar
      * Si el crédito es un valor positivo y el cliente está como OnDemand se cambiará a PrePaid con los créditos
      * Si el crédito es un valor positivo y el cliente está como PrePaid sumarán los créditos a los actuales

--- a/src/QuickFinkok.php
+++ b/src/QuickFinkok.php
@@ -365,13 +365,13 @@ class QuickFinkok
     }
 
     /**
-     * Obtiene un listado de clientes registrados, o solo uno si se especifica el RFC
+     * Obtiene los datos del RFC especificado
      *
      * @param string $filterByRfc
      * @return Registration\ObtainResult
      * @see https://wiki.finkok.com/doku.php?id=get
      */
-    public function customersObtain(string $filterByRfc = ''): Registration\ObtainResult
+    public function customersObtain(string $filterByRfc): Registration\ObtainResult
     {
         $command = new Registration\ObtainCommand($filterByRfc);
         $service = new Registration\ObtainService($this->settings());

--- a/src/Services/Registration/Customers.php
+++ b/src/Services/Registration/Customers.php
@@ -40,4 +40,13 @@ class Customers extends AbstractCollection
         }
         return null;
     }
+
+    public function merge(self $customers): self
+    {
+        $clone = clone $this;
+        foreach ($customers as $customer) {
+            $clone->collection->append($customer);
+        }
+        return $clone;
+    }
 }

--- a/src/Services/Registration/ObtainCommand.php
+++ b/src/Services/Registration/ObtainCommand.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 namespace PhpCfdi\Finkok\Services\Registration;
 
+use PhpCfdi\Finkok\Exceptions\InvalidArgumentException;
+
 class ObtainCommand
 {
     /** @var string */
     private $rfc;
 
-    public function __construct(string $rfc = '')
+    public function __construct(string $rfc)
     {
+        if ('' === $rfc) {
+            throw new InvalidArgumentException('Invalid RFC, cannot be empty');
+        }
+
         $this->rfc = $rfc;
     }
 

--- a/src/Services/Registration/ObtainCustomersCommand.php
+++ b/src/Services/Registration/ObtainCustomersCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Services\Registration;
+
+class ObtainCustomersCommand
+{
+    /** @var int */
+    private $page;
+
+    public function __construct(int $page)
+    {
+        $this->page = $page;
+    }
+
+    public function page(): int
+    {
+        return $this->page;
+    }
+}

--- a/src/Services/Registration/ObtainCustomersResult.php
+++ b/src/Services/Registration/ObtainCustomersResult.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Services\Registration;
+
+use PhpCfdi\Finkok\Services\AbstractResult;
+use stdClass;
+
+final class ObtainCustomersResult extends AbstractResult
+{
+    /** @var Customers */
+    private $customers;
+
+    public function __construct(stdClass $data)
+    {
+        parent::__construct($data, 'customersResult');
+        $customers = $this->findInDescendent($data, 'customersResult', 'users', 'ResellerUser');
+        $this->customers = new Customers(is_array($customers) ? $customers : []);
+    }
+
+    public function message(): string
+    {
+        return $this->get('message');
+    }
+
+    public function customers(): Customers
+    {
+        return $this->customers;
+    }
+
+    public function pagesInformation(): PageInformation
+    {
+        $message = $this->message();
+        return PageInformation::fromMessage($message);
+    }
+}

--- a/src/Services/Registration/ObtainCustomersService.php
+++ b/src/Services/Registration/ObtainCustomersService.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Services\Registration;
+
+use PhpCfdi\Finkok\Definitions\Services;
+use PhpCfdi\Finkok\FinkokSettings;
+
+class ObtainCustomersService
+{
+    /** @var FinkokSettings */
+    private $settings;
+
+    public function __construct(FinkokSettings $settings)
+    {
+        $this->settings = $settings;
+    }
+
+    public function settings(): FinkokSettings
+    {
+        return $this->settings;
+    }
+
+    public function obtainAll(): Customers
+    {
+        $page = 0;
+        $result = new Customers([]);
+
+        do {
+            $page = $page + 1;
+            $command = new ObtainCustomersCommand($page);
+            $current = $this->obtainPage($command);
+            $result = $result->merge($current->customers());
+        } while ($current->pagesInformation()->hasMorePages());
+
+        return $result;
+    }
+
+    public function obtainPage(ObtainCustomersCommand $command): ObtainCustomersResult
+    {
+        $soapCaller = $this->settings()->createCallerForService(
+            Services::registration(),
+            'username',
+            'password'
+        );
+        $rawResponse = $soapCaller->call('customers', [
+            'page' => $command->page(),
+        ]);
+        return new ObtainCustomersResult($rawResponse);
+    }
+}

--- a/src/Services/Registration/PageInformation.php
+++ b/src/Services/Registration/PageInformation.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Services\Registration;
+
+class PageInformation
+{
+    /** @var int */
+    private $firstRecord;
+
+    /** @var int */
+    private $lastRecord;
+
+    /** @var int */
+    private $totalRecords;
+
+    /** @var int */
+    private $currentPage;
+
+    /** @var int */
+    private $totalPages;
+
+    /** @var int */
+    private $pageLength;
+
+    public function __construct(
+        int $firstRecord,
+        int $lastRecord,
+        int $totalRecords,
+        int $currentPage,
+        int $totalPages,
+        int $pageLength
+    ) {
+        $this->firstRecord = $firstRecord;
+        $this->lastRecord = $lastRecord;
+        $this->totalRecords = $totalRecords;
+        $this->currentPage = $currentPage;
+        $this->totalPages = $totalPages;
+        $this->pageLength = $pageLength;
+    }
+
+    public static function empty(): self
+    {
+        return new self(1, 50, 0, 1, 1, 50);
+    }
+
+    public static function fromMessage(string $message): self
+    {
+        $found = preg_match('/^Showing (?<first>\d+) to (?<last>\d+) of (?<records>\d+) entries$/', $message, $matches);
+        if (1 !== $found) {
+            return self::empty();
+        }
+        $first = intval($matches['first']);
+        $last = intval($matches['last']);
+        $records = intval($matches['records']);
+        return self::fromValues($first, $last, $records);
+    }
+
+    public static function fromValues(int $first, int $last, int $records): self
+    {
+        $pageLength = $last - $first + 1;
+        if (0 === $pageLength) {
+            return new self($first, $last, $records, 1, 1, $pageLength);
+        }
+        $pages = intval(ceil($records / $pageLength));
+        $page = intval(round($last / $pageLength, 0));
+
+        return new self($first, $last, $records, $page, $pages, $pageLength);
+    }
+
+    public function firstRecord(): int
+    {
+        return $this->firstRecord;
+    }
+
+    public function lastRecord(): int
+    {
+        return $this->lastRecord;
+    }
+
+    public function totalRecords(): int
+    {
+        return $this->totalRecords;
+    }
+
+    public function currentPage(): int
+    {
+        return $this->currentPage;
+    }
+
+    public function totalPages(): int
+    {
+        return $this->totalPages;
+    }
+
+    public function pageLength(): int
+    {
+        return $this->pageLength;
+    }
+
+    public function hasMorePages(): bool
+    {
+        return $this->currentPage < $this->totalPages;
+    }
+}

--- a/tests/Integration/Services/Registration/ObtainCustomersServiceTest.php
+++ b/tests/Integration/Services/Registration/ObtainCustomersServiceTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Integration\Services\Registration;
+
+use PhpCfdi\Finkok\Services\Registration\ObtainCustomersCommand;
+use PhpCfdi\Finkok\Services\Registration\ObtainCustomersService;
+
+final class ObtainCustomersServiceTest extends RegistrationIntegrationTestCase
+{
+    protected function createService(): ObtainCustomersService
+    {
+        $settings = $this->createSettingsFromEnvironment();
+        return new ObtainCustomersService($settings);
+    }
+
+    public function testConsumeObtainCustomersServiceObtainPage(): void
+    {
+        $service = $this->createService();
+        $result = $service->obtainPage(new ObtainCustomersCommand(1));
+
+        $this->assertMatchesRegularExpression('/^Showing \d+ to \d+ of \d+ entries$/', $result->message());
+        $this->assertGreaterThanOrEqual(0, count($result->customers()));
+    }
+
+    public function testConsumeObtainCustomersServiceObtainAll(): void
+    {
+        $service = $this->createService();
+        $result = $service->obtainAll();
+
+        $this->assertGreaterThanOrEqual(0, count($result));
+
+        $this->assertNull($result->findByRfc(self::CUSTOMER_NON_EXISTENT));
+
+        $customer = $result->getByRfc('EKU9003173C9');
+        $this->assertSame('EKU9003173C9', $customer->rfc());
+    }
+}

--- a/tests/Integration/Services/Registration/ObtainServiceTest.php
+++ b/tests/Integration/Services/Registration/ObtainServiceTest.php
@@ -39,20 +39,4 @@ final class ObtainServiceTest extends RegistrationIntegrationTestCase
         $this->assertTrue($customer->status()->isActive());
         $this->assertTrue($customer->customerType()->isOndemand());
     }
-
-    public function testConsumeObtainServiceGettingAllRecords(): void
-    {
-        $service = $this->createService();
-        $result = $service->obtain(new ObtainCommand());
-        if ('RFC Invalido' === $result->message()) {
-            $this->markTestSkipped(<<< MESSAGE
-                Finkok does not have implemented the list of customers.
-                See https://support.finkok.com/support/tickets/66516
-                MESSAGE);
-        }
-
-        $this->assertSame('', $result->message());
-        $this->assertGreaterThanOrEqual(1, count($result->customers()));
-        $this->assertSame('EKU9003173C9', $result->customers()->getByRfc('EKU9003173C9')->rfc());
-    }
 }

--- a/tests/Unit/QuickFinkokTest.php
+++ b/tests/Unit/QuickFinkokTest.php
@@ -379,7 +379,7 @@ final class QuickFinkokTest extends TestCase
     public function testCustomersObtain(): void
     {
         /** @var stdClass $rawData */
-        $rawData = json_decode($this->fileContentPath('registration-get-response-2-items.json'));
+        $rawData = json_decode($this->fileContentPath('registration-get-response.json'));
         $finkok = $this->createdPreparedQuickFinkok($rawData);
 
         $result = $finkok->customersObtain('x-rfc');

--- a/tests/Unit/QuickFinkokTest.php
+++ b/tests/Unit/QuickFinkokTest.php
@@ -390,6 +390,24 @@ final class QuickFinkokTest extends TestCase
         $this->assertEquals($rawData, $result->rawData());
     }
 
+    public function testCustomersObtainAll(): void
+    {
+        /** @var stdClass $rawData */
+        $rawData = json_decode($this->fileContentPath('registration-customers-response-2-items.json'));
+        $finkok = $this->createdPreparedQuickFinkok($rawData);
+
+        $result = $finkok->customersObtainAll();
+
+        $this->performTestOnLatestCall('customers', [
+            'page' => 1,
+        ]);
+
+        $this->assertCount(2, $result);
+        $this->assertNotNull($result->findByRfc('MAG041126GT8'));
+        $this->assertNotNull($result->findByRfc('LAN7008173R5'));
+        $this->assertNull($result->findByRfc('AAA010101AAA'));
+    }
+
     public function testCustomerGetContracts(): void
     {
         /** @var stdClass $rawData */

--- a/tests/Unit/Services/Registration/CustomersTest.php
+++ b/tests/Unit/Services/Registration/CustomersTest.php
@@ -49,4 +49,30 @@ final class CustomersTest extends TestCase
         $this->expectExceptionMessage('There is no customer with RFC AAA010101AAA');
         $customers->getByRfc('AAA010101AAA');
     }
+
+    public function testMerge(): void
+    {
+        $firstList = [
+            (object) ['taxpayer_id' => 'AAA010101AAA', 'status' => 'S', 'counter' => 0, 'credit' => 0],
+            (object) ['taxpayer_id' => 'BBB010101AAA', 'status' => 'S', 'counter' => 0, 'credit' => 0],
+        ];
+        $firstCustomers = new Customers($firstList);
+
+        $secondList = [
+            (object) ['taxpayer_id' => 'CCC010101AAA', 'status' => 'S', 'counter' => 0, 'credit' => 0],
+            (object) ['taxpayer_id' => 'DDD010101AAA', 'status' => 'S', 'counter' => 0, 'credit' => 0],
+            (object) ['taxpayer_id' => 'EEE010101AAA', 'status' => 'S', 'counter' => 0, 'credit' => 0],
+        ];
+        $secondCustomers = new Customers($secondList);
+
+        $merged = $firstCustomers->merge($secondCustomers);
+
+        $this->assertCount(5, $merged);
+        foreach ($firstCustomers as $customer) {
+            $this->assertSame($customer, $merged->findByRfc($customer->rfc()));
+        }
+        foreach ($secondCustomers as $customer) {
+            $this->assertSame($customer, $merged->findByRfc($customer->rfc()));
+        }
+    }
 }

--- a/tests/Unit/Services/Registration/CustomersTest.php
+++ b/tests/Unit/Services/Registration/CustomersTest.php
@@ -20,21 +20,21 @@ final class CustomersTest extends TestCase
     public function testFindByRfc(): void
     {
         /** @var stdClass $data */
-        $data = json_decode($this->fileContentPath('registration-get-response-2-items.json'));
+        $data = json_decode($this->fileContentPath('registration-get-response.json'));
         $customers = new Customers($data->getResult->users->ResellerUser);
-        $known = $customers->findByRfc('LAN7008173R5');
+        $known = $customers->findByRfc('MAG041126GT8');
         if (null === $known) {
             $this->fail('Could not find a predefined customer in customers');
         }
-        $this->assertSame('LAN7008173R5', $known->rfc(), 'known rfc finding must match');
+        $this->assertSame('MAG041126GT8', $known->rfc(), 'known rfc finding must match');
         $this->assertNull($customers->findByRfc('AAA010101AAA'));
     }
 
     public function testGetByRfcUsingExistentRfc(): void
     {
-        $expectedRfc = 'LAN7008173R5';
+        $expectedRfc = 'MAG041126GT8';
         /** @var stdClass $data */
-        $data = json_decode($this->fileContentPath('registration-get-response-2-items.json'));
+        $data = json_decode($this->fileContentPath('registration-get-response.json'));
         $customers = new Customers($data->getResult->users->ResellerUser);
         $this->assertSame($expectedRfc, $customers->getByRfc($expectedRfc)->rfc());
     }
@@ -42,7 +42,7 @@ final class CustomersTest extends TestCase
     public function testGetByRfcUsingNonExistentRfcThrowsException(): void
     {
         /** @var stdClass $data */
-        $data = json_decode($this->fileContentPath('registration-get-response-2-items.json'));
+        $data = json_decode($this->fileContentPath('registration-get-response.json'));
         $customers = new Customers($data->getResult->users->ResellerUser);
 
         $this->expectException(LogicException::class);

--- a/tests/Unit/Services/Registration/ObtainCommandTest.php
+++ b/tests/Unit/Services/Registration/ObtainCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\Finkok\Tests\Unit\Services\Registration;
 
+use PhpCfdi\Finkok\Exceptions\InvalidArgumentException;
 use PhpCfdi\Finkok\Services\Registration\ObtainCommand;
 use PhpCfdi\Finkok\Tests\TestCase;
 
@@ -15,9 +16,10 @@ final class ObtainCommandTest extends TestCase
         $this->assertSame('x-rfc', $command->rfc());
     }
 
-    public function testObtainCommandCreationWithoutRfc(): void
+    public function testObtainCommandCreationWithEmptyRfc(): void
     {
-        $command = new ObtainCommand();
-        $this->assertSame('', $command->rfc());
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid RFC, cannot be empty');
+        new ObtainCommand('');
     }
 }

--- a/tests/Unit/Services/Registration/ObtainCustomersPageInformationTest.php
+++ b/tests/Unit/Services/Registration/ObtainCustomersPageInformationTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Unit\Services\Registration;
+
+use PhpCfdi\Finkok\Services\Registration\PageInformation;
+use PhpCfdi\Finkok\Tests\TestCase;
+
+final class ObtainCustomersPageInformationTest extends TestCase
+{
+    public function testCreateFromMessage(): void
+    {
+        $message = 'Showing 51 to 100 of 151 entries';
+        $info = PageInformation::fromMessage($message);
+        $this->assertSame(51, $info->firstRecord());
+        $this->assertSame(100, $info->lastRecord());
+        $this->assertSame(151, $info->totalRecords());
+        $this->assertSame(50, $info->pageLength());
+        $this->assertSame(2, $info->currentPage());
+        $this->assertSame(4, $info->totalPages());
+    }
+}

--- a/tests/Unit/Services/Registration/ObtainCustomersResultTest.php
+++ b/tests/Unit/Services/Registration/ObtainCustomersResultTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Unit\Services\Registration;
+
+use PhpCfdi\Finkok\Services\Registration\ObtainCustomersResult;
+use PhpCfdi\Finkok\Services\Registration\PageInformation;
+use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
+
+final class ObtainCustomersResultTest extends TestCase
+{
+    public function testResultUsingPredefinedResponses(): void
+    {
+        /** @var stdClass $data */
+        $data = json_decode($this->fileContentPath('registration-customers-response-2-items.json'));
+        $result = new ObtainCustomersResult($data);
+        $this->assertSame('Showing 1 to 50 of 2 entries', $result->message());
+        $this->assertEquals(PageInformation::fromValues(1, 50, 2), $result->pagesInformation());
+        $this->assertCount(2, $result->customers());
+    }
+
+    public function testPagesInformation(): void
+    {
+        $message = 'Showing 51 to 100 of 151 entries';
+        $expectedInformation = PageInformation::fromValues(51, 100, 151);
+        $result = new ObtainCustomersResult((object) ['customersResult' => (object) ['message' => $message]]);
+        $this->assertEquals($expectedInformation, $result->pagesInformation());
+    }
+}

--- a/tests/Unit/Services/Registration/ObtainCustomersServiceTest.php
+++ b/tests/Unit/Services/Registration/ObtainCustomersServiceTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Finkok\Tests\Unit\Services\Registration;
+
+use PhpCfdi\Finkok\Services\Registration\ObtainCustomersCommand;
+use PhpCfdi\Finkok\Services\Registration\ObtainCustomersService;
+use PhpCfdi\Finkok\Tests\Fakes\FakeSoapFactory;
+use PhpCfdi\Finkok\Tests\TestCase;
+use stdClass;
+
+final class ObtainCustomersServiceTest extends TestCase
+{
+    public function testServiceUsingPreparedResult(): void
+    {
+        /** @var stdClass $preparedResult */
+        $preparedResult = json_decode(TestCase::fileContentPath('registration-customers-response-2-items.json'));
+
+        $soapFactory = new FakeSoapFactory();
+        $soapFactory->preparedResult = $preparedResult;
+
+        $settings = $this->createSettingsFromEnvironment($soapFactory);
+        $service = new ObtainCustomersService($settings);
+
+        $page = 2;
+
+        $command = new ObtainCustomersCommand($page);
+        $service->obtainPage($command);
+
+        $caller = $soapFactory->latestSoapCaller;
+        $this->assertArrayHasKey('page', $caller->latestCallParameters);
+        $this->assertSame($page, $caller->latestCallParameters['page']);
+    }
+}

--- a/tests/Unit/Services/Registration/ObtainResultTest.php
+++ b/tests/Unit/Services/Registration/ObtainResultTest.php
@@ -13,9 +13,9 @@ final class ObtainResultTest extends TestCase
     public function testResultUsingPredefinedResponses(): void
     {
         /** @var stdClass $data */
-        $data = json_decode($this->fileContentPath('registration-get-response-2-items.json'));
+        $data = json_decode($this->fileContentPath('registration-get-response.json'));
         $result = new ObtainResult($data);
         $this->assertSame('predefined-message', $result->message());
-        $this->assertCount(2, $result->customers());
+        $this->assertCount(1, $result->customers());
     }
 }

--- a/tests/Unit/Services/Registration/ObtainServiceTest.php
+++ b/tests/Unit/Services/Registration/ObtainServiceTest.php
@@ -15,7 +15,7 @@ final class ObtainServiceTest extends TestCase
     public function testServiceUsingPreparedResultWithRfc(): void
     {
         /** @var stdClass $preparedResult */
-        $preparedResult = json_decode(TestCase::fileContentPath('registration-get-response-2-items.json'));
+        $preparedResult = json_decode(TestCase::fileContentPath('registration-get-response.json'));
 
         $soapFactory = new FakeSoapFactory();
         $soapFactory->preparedResult = $preparedResult;
@@ -23,10 +23,10 @@ final class ObtainServiceTest extends TestCase
         $settings = $this->createSettingsFromEnvironment($soapFactory);
         $service = new ObtainService($settings);
 
-        $command = new ObtainCommand('LAN7008173R5');
+        $command = new ObtainCommand('MAG041126GT8');
         $result = $service->obtain($command);
         $this->assertSame('predefined-message', $result->message());
-        $this->assertCount(2, $result->customers());
+        $this->assertCount(1, $result->customers());
 
         $caller = $soapFactory->latestSoapCaller;
         $this->assertSame('get', $caller->latestCallMethodName);

--- a/tests/Unit/Services/Registration/ObtainServiceTest.php
+++ b/tests/Unit/Services/Registration/ObtainServiceTest.php
@@ -34,23 +34,4 @@ final class ObtainServiceTest extends TestCase
         $this->assertArrayHasKey('taxpayer_id', $caller->latestCallParameters);
         $this->assertSame($command->rfc(), $caller->latestCallParameters['taxpayer_id']);
     }
-
-    public function testServiceUsingPreparedResultWithoutRfc(): void
-    {
-        /** @var stdClass $preparedResult */
-        $preparedResult = json_decode(TestCase::fileContentPath('registration-get-response-2-items.json'));
-
-        $soapFactory = new FakeSoapFactory();
-        $soapFactory->preparedResult = $preparedResult;
-
-        $settings = $this->createSettingsFromEnvironment($soapFactory);
-        $service = new ObtainService($settings);
-
-        $command = new ObtainCommand();
-        $service->obtain($command);
-
-        $caller = $soapFactory->latestSoapCaller;
-        $this->assertArrayHasKey('taxpayer_id', $caller->latestCallParameters);
-        $this->assertSame('', $caller->latestCallParameters['taxpayer_id']);
-    }
 }

--- a/tests/_files/registration-customers-response-2-items.json
+++ b/tests/_files/registration-customers-response-2-items.json
@@ -1,0 +1,21 @@
+{
+  "customersResult": {
+    "message": "Showing 1 to 50 of 2 entries",
+    "users": {
+      "ResellerUser": [
+        {
+          "status": "S",
+          "counter": 0,
+          "taxpayer_id": "MAG041126GT8",
+          "credit": 0
+        },
+        {
+          "status": "A",
+          "counter": 26,
+          "taxpayer_id": "LAN7008173R5",
+          "credit": 74
+        }
+      ]
+    }
+  }
+}

--- a/tests/_files/registration-get-response.json
+++ b/tests/_files/registration-get-response.json
@@ -8,12 +8,6 @@
           "counter": 0,
           "taxpayer_id": "MAG041126GT8",
           "credit": 0
-        },
-        {
-          "status": "A",
-          "counter": 26,
-          "taxpayer_id": "LAN7008173R5",
-          "credit": 74
         }
       ]
     }


### PR DESCRIPTION
Se reportó que el webservice `Registration#Get` no estaba aceptando un RFC vacío para devolver el listado
de clientes. La respuesta de Finkok fue implementar un nuevo método `Registration#Customers` que devuelve
el listado de clientes paginado. El método `Registration#Get` ya no permitirá devolver un listado de clientes. 

Se agregan los métodos `Finkok::registrationCustomers` y `QuickFinkok::customersObtainAll`
para consumir `Registration#Customers`.

El método `Finkok::registrationCustomers(ObtainCustomersCommand $command): ObtainCustomersResult` devuelve
el resultado de una sola página, con toda la información: mensaje e información de paginado.

El método `QuickFinkok::customersObtainAll` devuelve solamente el listado de clientes consumiendo
todas las páginas necesarias.

Se cambió el año en el archivo de licencia, ¡Feliz 2023!.