### PR TITLE
Propuesta de versión 0.5.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: '0 16 * * 0' # sunday 16:00
 
+# Actions
+# shivammathur/setup-php@v2 https://github.com/marketplace/actions/setup-php-action
+
 jobs:
 
   composer-normalize:
@@ -33,7 +36,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2 # see https://github.com/marketplace/actions/setup-php-action
+        uses: shivammathur/setup-php@v2
         with:
           php-version: '8.2'
           coverage: none
@@ -50,7 +53,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2 # see https://github.com/marketplace/actions/setup-php-action
+        uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
           coverage: none
@@ -99,7 +102,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2 # see https://github.com/marketplace/actions/setup-php-action
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
           coverage: none

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: build
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ "main" ]
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,13 +55,15 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:
           fail-fast: true
       - name: Code style (php-cs-fixer)
         run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
+        env:
+          PHP_CS_FIXER_IGNORE_ENV: 1
 
   phpstan:
     name: Code analysis (phpstan)

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -2,6 +2,7 @@ name: functional-tests
 on:
   # secrets are not passed to workflows that are triggered by a pull request from a fork.
   # see https://docs.github.com/en/actions/reference/encrypted-secrets
+  workflow_dispatch:
   push:
     branches: [ 'main' ]
 

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.13.2" installed="3.13.2" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="^1.9.6" installed="1.9.6" location="./tools/phpstan" copy="false"/>
-  <phar name="composer-normalize" version="^2.29.0" installed="2.29.0" location="./tools/composer-normalize" copy="false"/>
+  <phar name="phpcs" version="^3.7.2" installed="3.7.2" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.7.2" installed="3.7.2" location="./tools/phpcbf" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.17.0" installed="3.17.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpstan" version="^1.10.16" installed="1.10.16" location="./tools/phpstan" copy="false"/>
+  <phar name="composer-normalize" version="^2.31.0" installed="2.31.0" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 - 2023 PhpCfdi https://www.phpcfdi.com
+Copyright (c) 2019 - 2023 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
             "@php tools/phpcs --colors -sp"
         ],
         "dev:coverage": [
-            "@php -dzend_extension=xdebug.so vendor/bin/phpunit --verbose --coverage-html build/coverage/html/"
+            "@php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --verbose --coverage-html build/coverage/html/"
         ],
         "dev:fix-style": [
             "@php tools/composer-normalize normalize",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,20 @@ Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor e
 
 Estos cambios se aplican y se publican, pero aún no son parte de una versión liberada.
 
+## Versión 0.5.3 2023-06-06
+
+Se agrega la información de la excepción al momento de hacer la llamada SOAP.
+Si la excepción no implementa `\JsonSerializable` se exporta como texto resultado de `print_r`.
+
+Se realizan los siguientes cambios en desarrollo:
+
+- Se corrige el método `QuickFinkokTest#obtainParameterFromLatestCall` para que devuelva una cadena de texto.
+  Con este cambio se corrige el problema detectado por PHPStan.
+- En el proceso de integración continua, en el trabajo `php-cs-fixer` se usa PHP 8.2.
+- Se cambian los comentarios de ubicación de la imagen `shivammathur/setup-php@v2` al inicio.
+- Se corrige la acción de composer `dev:coverage`, faltaba `-dxdebug.mode=coverage`.
+- Se permite ejecutar los trabajos a voluntad, agregando `workflow_dispatch`.
+
 ## Versión 0.5.2 2023-01-03
 
 Se reportó que el webservice `Registration#Get` no estaba aceptando un RFC vacío para devolver el listado

--- a/src/SoapCaller.php
+++ b/src/SoapCaller.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\Finkok;
 
+use JsonSerializable;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -63,7 +64,11 @@ class SoapCaller implements LoggerAwareInterface
             return $result;
         } catch (Throwable $exception) {
             $this->logger->error(strval(json_encode(
-                ['method' => $methodName, 'parameters' => $finalParameters] + $this->extractSoapClientTrace($soap),
+                array_merge(
+                    ['method' => $methodName, 'parameters' => $finalParameters],
+                    $this->extractSoapClientTrace($soap),
+                    ['exception' => ($exception instanceof JsonSerializable) ? $exception : print_r($exception, true)]
+                ),
                 JSON_PRETTY_PRINT
             )));
             throw new RuntimeException(sprintf('Fail soap call to %s', $methodName), 0, $exception);


### PR DESCRIPTION
Se agrega la información de la excepción al momento de hacer la llamada SOAP.
Si la excepción no implementa `\JsonSerializable` se exporta como texto resultado de `print_r`.

Se realizan los siguientes cambios en desarrollo:

- Se corrige el método `QuickFinkokTest#obtainParameterFromLatestCall` para que devuelva una cadena de texto.
  Con este cambio se corrige el problema detectado por PHPStan.
- En el proceso de integración continua, en el trabajo `php-cs-fixer` se usa PHP 8.2.
- Se cambian los comentarios de ubicación de la imagen `shivammathur/setup-php@v2` al inicio.
- Se corrige la acción de composer `dev:coverage`, faltaba `-dxdebug.mode=coverage`.
- Se permite ejecutar los trabajos a voluntad, agregando `workflow_dispatch`.