### PR TITLE
Correcciones a 0.5.3 antes de liberar

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -43,9 +43,6 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
-      - name: Remove unused development dependencies
-        run: composer remove squizlabs/php_codesniffer friendsofphp/php-cs-fixer phpstan/phpstan --dev --no-interaction --no-progress --no-update
-
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -61,7 +61,7 @@ Se documenta el error de funcionamiento en Finkok en el método `Registration#Ge
 
 #### 2022-09-05
 
-El proceso de integración contínua con las herramientas de desarrollo actualizadas falló,
+El proceso de integración continua con las herramientas de desarrollo actualizadas falló,
 por lo que se aplicaron los siguientes cambios:
 
 - Se eliminan las anotaciones de definición de tipos de datos para la constante `Finkok::SERVICES_MAP`.
@@ -210,7 +210,7 @@ En la versión 0.3.0 se mencionó que la fachada `Finkok::datetime()` podía seg
 Es necesario que se le entregue el comando `DatetimeCommand`.
 Con este cambio, se elimina el método `datetimePostalCode`.
 
-Cambios en integración contínua:
+Cambios en integración continua:
 
 - Se deja de usar Travis-CI en favor de GitHub Actions.
 - Se actualizan los archivos a su versión en español: Código de conducta, contribuciones.
@@ -256,7 +256,7 @@ Cambios en el entorno de pruebas (2020-09-18). Solo se afecta la rama principal,
 - El build estaba roto por un problema de tipos detectado por `phpstan` debido a un "soft breaking compatibility change"
   introducido por `symfony/dotenv:5.1`, se corrige el problema en `tests/bootstrap.php`.
 - Se crea `Finkok\Tests\LoggerPrinter` para facilitar la escritura de los volcados de comunicación.
-- Se agrega `tests/stamp-precfdi-devenv.php` para estampar un precfdi usando la configuración del entorno de desarrollo.
+- Se agrega `tests/stamp-precfdi-devenv.php` para estampar un PreCfdi usando la configuración del entorno de desarrollo.
 - Cambios menores en las pruebas.
 
 ## Versión 0.2.7 2020-02-10
@@ -287,7 +287,7 @@ Cambios en el entorno de pruebas (2020-09-18). Solo se afecta la rama principal,
     - Se actualiza de `phpstan/phpstan-shim: ^0.11` a `phpstan/phpstan: ^0.12`.
     - Se actualiza a `phpunit/phpunit: ^8.5` porque el XSD de la versión previa no está disponible.
     - Se crean nuevas tareas de desarrollo y mejora.
-- Issues: A pesar de haber impementado la Cancelación de retención, el test de integración está fallando por un
+- Issues: A pesar de haber implementado la Cancelación de retención, el test de integración está fallando por un
   error en el servicio de pruebas del SAT.
 
 ## Versión 0.2.5 2020-01-14

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,19 +6,21 @@ Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor e
 
 Estos cambios se aplican y se publican, pero aún no son parte de una versión liberada.
 
-## Versión 0.5.3 2023-06-06
+## Versión 0.5.3 2023-06-07
 
 Se agrega la información de la excepción al momento de hacer la llamada SOAP.
-Si la excepción no implementa `\JsonSerializable` se exporta como texto resultado de `print_r`.
+Si la excepción no implementa `JsonSerializable` se exporta como texto resultado de `print_r`.
 
 Se realizan los siguientes cambios en desarrollo:
 
+- Se cambian las pruebas de CFDI de Retenciones y pagos a versión 2.0.
 - Se corrige el método `QuickFinkokTest#obtainParameterFromLatestCall` para que devuelva una cadena de texto.
   Con este cambio se corrige el problema detectado por PHPStan.
 - En el proceso de integración continua, en el trabajo `php-cs-fixer` se usa PHP 8.2.
 - Se cambian los comentarios de ubicación de la imagen `shivammathur/setup-php@v2` al inicio.
 - Se corrige la acción de composer `dev:coverage`, faltaba `-dxdebug.mode=coverage`.
 - Se permite ejecutar los trabajos a voluntad, agregando `workflow_dispatch`.
+- Se quita el paso para remover dependencias de desarrollo que ya no existen.
 
 ## Versión 0.5.2 2023-01-03
 

--- a/tests/Factories/PreCfdiRetentionCreatorHelper.php
+++ b/tests/Factories/PreCfdiRetentionCreatorHelper.php
@@ -6,7 +6,6 @@ namespace PhpCfdi\Finkok\Tests\Factories;
 
 use CfdiUtils\Certificado\Certificado;
 use CfdiUtils\Elements\Dividendos10\Dividendos;
-use CfdiUtils\Elements\PagosAExtranjeros10\Pagosaextranjeros;
 use CfdiUtils\Nodes\NodeInterface;
 use CfdiUtils\Retenciones\RetencionesCreator20;
 use DateTimeImmutable;
@@ -197,26 +196,5 @@ final class PreCfdiRetentionCreatorHelper
         ], $dividOUtil));
 
         return $dividendos;
-    }
-
-    /**
-     * @param array<string, string> $pagosAExtranjeros
-     * @param array<string, string> $noBeneficiario
-     * @return Pagosaextranjeros<NodeInterface>
-     */
-    public function createPagosAExtranjerosNoBeneficiario(
-        array $pagosAExtranjeros = [],
-        array $noBeneficiario = []
-    ): Pagosaextranjeros {
-        $pagosAExtranjeros = new Pagosaextranjeros(array_merge([
-            'EsBenefEfectDelCobro' => 'NO',
-        ], $pagosAExtranjeros));
-        $pagosAExtranjeros->addNoBeneficiario(array_merge([
-            'PaisDeResidParaEfecFisc' => 'US',
-            'ConceptoPago' => '3', // 3 - Persona moral
-            'DescripcionConcepto' => 'Dividendos provenientes de CUFIN al 31 de Dic 2013',
-        ], $noBeneficiario));
-
-        return $pagosAExtranjeros;
     }
 }

--- a/tests/Factories/PreCfdiRetentionCreatorHelper.php
+++ b/tests/Factories/PreCfdiRetentionCreatorHelper.php
@@ -47,7 +47,7 @@ final class PreCfdiRetentionCreatorHelper
         string $emisorRfc,
         string $emisorName,
         string $emisorLocation,
-        string $emisorRegimen,
+        string $emisorRegimen
     ) {
         $this->certificate = new Certificado($cerFile);
         $this->emisorRfc = $emisorRfc;

--- a/tests/Integration/Services/Cancel/GetRelatedSignatureServiceTest.php
+++ b/tests/Integration/Services/Cancel/GetRelatedSignatureServiceTest.php
@@ -91,8 +91,6 @@ final class GetRelatedSignatureServiceTest extends IntegrationTestCase
             sleep(5);
         }
 
-        print_r($result);
-
         $this->assertSame($third->uuid(), $result->parents()->first()->uuid());
         $this->assertSame($first->uuid(), $result->children()->first()->uuid());
         $this->assertEmpty($result->error());


### PR DESCRIPTION
- Se corrigen los test de integración de Retenciones para usar RET 2.0.
- Se quita el paso para remover dependencias de desarrollo que ya no existen.