### PR TITLE
Instalar los recursos XML en las pruebas funcionales

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -46,6 +46,13 @@ jobs:
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
 
+      - name: Install SAT XML resources
+        shell: bash
+        run: |
+          git clone --depth 1 https://github.com/phpcfdi/resources-sat-xml resources-sat-xml-cloned
+          mv resources-sat-xml-cloned/resources vendor/eclipxe/cfdiutils/build/resources
+          rm -r -f resources-sat-xml-cloned
+
       - name: Set up environment file
         run: gpg --quiet --batch --yes --decrypt --passphrase="$ENV_GPG_SECRET" --output tests/.env tests/.env-testing.enc
         env:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,9 @@ Estos cambios se aplican y se publican, pero aún no son parte de una versión l
 
 Se actualiza la FIEL y el CSD del RFC `EKU9003173C9` a versiones recientes, las anteriores habían expirado.
 
+En el proceso de integración continua de pruebas funcionales, instalar los recursos XML para evitar la descarga 
+y múltiples fallas por parte del SAT.
+
 Se actualizan las herramientas de desarrollo.
 
 ## Versión 0.5.3 2023-06-07


### PR DESCRIPTION
En el proceso de integración continua de pruebas funcionales, instalar los recursos XML para evitar la descarga y múltiples fallas por parte del SAT.
