### PR TITLE
Maintenance 2024-03-09 (version 0.5.4)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,3 +22,6 @@
 /phpcs.xml.dist             export-ignore
 /phpstan.neon.dist          export-ignore
 /phpunit.xml.dist           export-ignore
+
+# Do not count these files on github code language
+/tests/_files/**            linguist-detectable=false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: composer-normalize
         env:
@@ -39,7 +39,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -56,7 +56,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:
@@ -73,7 +73,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: composer:v2, phpstan
           extensions: soap

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,8 +63,6 @@ jobs:
           fail-fast: true
       - name: Code style (php-cs-fixer)
         run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
-        env:
-          PHP_CS_FIXER_IGNORE_ENV: 1
 
   phpstan:
     name: Code analysis (phpstan)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,18 +94,18 @@ jobs:
         run: phpstan analyse --no-progress --verbose
 
   unit-tests:
-    name: Tests on PHP ${{ matrix.php-versions }}
+    name: Tests on PHP ${{ matrix.php-version }}
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php-version }}
           coverage: none
           tools: composer:v2
           extensions: soap

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -35,7 +35,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -52,7 +52,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -71,7 +71,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -85,7 +85,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -103,7 +103,7 @@ jobs:
         php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -117,7 +117,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # required for sudo-bot/action-scrutinizer
 
@@ -37,7 +37,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           extensions: soap
           coverage: xdebug
           tools: composer:v2

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpcs" version="^3.7.2" installed="3.9.0" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.7.2" installed="3.9.0" location="./tools/phpcbf" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.18.0" installed="3.51.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="^1.10.19" installed="1.10.60" location="./tools/phpstan" copy="false"/>
-  <phar name="composer-normalize" version="^2.31.0" installed="2.42.0" location="./tools/composer-normalize" copy="false"/>
+  <phar name="phpcs" version="^3.9.0" installed="3.9.0" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.9.0" installed="3.9.0" location="./tools/phpcbf" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.51.0" installed="3.51.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpstan" version="^1.10.60" installed="1.10.60" location="./tools/phpstan" copy="false"/>
+  <phar name="composer-normalize" version="^2.42.0" installed="2.42.0" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpcs" version="^3.7.2" installed="3.7.2" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.7.2" installed="3.7.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.18.0" installed="3.18.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="^1.10.19" installed="1.10.19" location="./tools/phpstan" copy="false"/>
-  <phar name="composer-normalize" version="^2.31.0" installed="2.31.0" location="./tools/composer-normalize" copy="false"/>
+  <phar name="phpcs" version="^3.7.2" installed="3.9.0" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.7.2" installed="3.9.0" location="./tools/phpcbf" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.18.0" installed="3.51.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpstan" version="^1.10.19" installed="1.10.60" location="./tools/phpstan" copy="false"/>
+  <phar name="composer-normalize" version="^2.31.0" installed="2.42.0" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -22,7 +22,7 @@ return (new PhpCsFixer\Config())
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
-        'function_typehint_space' => true,
+        'type_declaration_spaces' => true,
         'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribuciones
 
-Las contribuciones son bienvenidas. Aceptamos *Pull Requests* en [el repositorio GitHub][homepage].
+Las contribuciones son bienvenidas. Aceptamos *Pull Requests* en [el repositorio GitHub][project].
 
 Este proyecto se apega al siguiente [Código de Conducta][coc].
 Al participar en este proyecto y en su comunidad, deberás seguir este código.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 - 2023 PhpCfdi https://www.phpcfdi.com/
+Copyright (c) 2019 - 2024 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Su cancelación es inmediata (al contrario de la solicitud de cancelación actua
 * `cancelSignature(Retentions\CancelSignatureCommand $command): Retentions\StampedResult`
 
 Para descargar una retención debe usar el servicio `Utilerias`, método `get_xml` que está implementado previamente.
-Igualmente se ha creado el método `QuickFinkok::retentionDownload($uuid, $rfc)` para simplificar su implementación.
+Igualmente, se ha creado el método `QuickFinkok::retentionDownload($uuid, $rfc)` para simplificar su implementación.
 
 ### Ayuda para firmado XML para SAT y Finkok
 
@@ -246,7 +246,7 @@ También utilizamos [Versionado Semántico 2.0.0](docs/SEMVER.md) por lo que pue
 sin temor a romper tu aplicación.
 
 | Versión de la librería | Versión de PHP | Fecha de lanzamiento |
-| ---                    | ---            | ---                  |
+|------------------------|----------------|----------------------|
 | 0.1.0                  | 7.2, 7.3 y 7.4 | 2019-03-29           |
 | 0.3.0                  | 7.3, 7.4 y 8.0 | 2021-03-18           |
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,39 @@ Durante el proceso de implementación he creado diversas notas y documentos:
     - [X] [El valor `CodEstatus` está ausente en la cancelación de CFDI de Retenciones](docs/issues/CancelacionRetencionesCodEstatus.md)
     - [X] [El método `Registration#Get` con `taxpayer_id` vacío no devuelve el listado de clientes](docs/issues/RegistrationGetNoList.md)
 
+## Capturar conversación HTTP
+
+Algunas veces, al reportar a Finkok un problema, nos solicitan la conversación HTTP (*Request* y *Response*)
+para poder revisar el problema sobre la información enviada.
+
+Esta librería genera mensajes utilizando *PSR-3: Logger Interface*, y se utiliza dentro del objeto `SoapFactory`
+para crear un `SoapCaller`. Este objeto envía dos tipos de mensajes: `LogLevel::ERROR` cuando ocurre un error al
+momento de establecer comunicación con los servicios, y `LogLevel::DEBUG` cuando se ejecutó una llamada SOAP.
+Ambos mensajes están representados como una cadena en formato JSON, por lo que, para leerla correctamente
+es importante decodificarla.
+
+La clase [`PhpCfdi\Finkok\Tests\LoggerPrinter`](https://github.com/phpcfdi/finkok/blob/main/tests/LoggerPrinter.php)
+es un *ejemplo de implementación* de `LoggerInterface` que manda los mensajes recibidos a la salida estándar o
+a un archivo. Es importante notar que el objeto `LoggerPrinter` no está disponible en el paquete, sin embargo,
+lo puedes descargar y poner dentro de tu proyecto con tu espacio de nombres.
+
+De igual forma, se puede utilizar cualquier objeto que implemente `LoggerInterface`, por ejemplo, en Laravel se
+puede usar `$logger = app(Psr\Log\LoggerInterface::class)`. Pero recuerda que, una vez que tengas el mensaje,
+deberás decodificarlo de JSON a texto plano.
+
+Para establecer el objeto `Logger` es recomendable hacerlo de la siguiente forma:
+
+```php
+use PhpCfdi\Finkok\FinkokEnvironment;
+use PhpCfdi\Finkok\FinkokSettings;
+use PhpCfdi\Finkok\Tests\LoggerPrinter;
+
+$logger = new LoggerPrinter('/tmp/finkok.log');
+
+$settings = new FinkokSettings('user@host.com', 'secret', FinkokEnvironment::makeProduction());
+$settings->soapFactory()->setLogger($logger);
+```
+
 ## Compatibilidad
 
 Esta librería se mantendrá compatible con al menos la versión con

--- a/README.md
+++ b/README.md
@@ -271,10 +271,10 @@ Esta librería se mantendrá compatible con al menos la versión con
 También utilizamos [Versionado Semántico 2.0.0](docs/SEMVER.md) por lo que puedes usar esta librería
 sin temor a romper tu aplicación.
 
-| Versión de la librería | Versión de PHP | Fecha de lanzamiento |
-|------------------------|----------------|----------------------|
-| 0.1.0                  | 7.2, 7.3 y 7.4 | 2019-03-29           |
-| 0.3.0                  | 7.3, 7.4 y 8.0 | 2021-03-18           |
+| Versión de la librería | Versión de PHP                | Fecha de lanzamiento |
+|------------------------|-------------------------------|----------------------|
+| 0.1.0                  | 7.2, 7.3 y 7.4                | 2019-03-29           |
+| 0.3.0                  | 7.3, 7.4, 8.0, 8.1, 8.2 y 8.3 | 2021-03-18           |
 
 ## Contribuciones
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,6 @@ composer require phpcfdi/finkok
 ## Ejemplo básico de uso
 
 ```php
-<?php
-
-declare(strict_types=1);
-
 use PhpCfdi\Finkok\FinkokEnvironment;
 use PhpCfdi\Finkok\FinkokSettings;
 use PhpCfdi\Finkok\QuickFinkok;
@@ -191,9 +187,6 @@ La clase `QuickFinkok` ahorra el proceso de firmar peticiones y lo hace de forma
 se muestra el siguiente ejemplo de cancelación firmada de 1 UUID con certificado y llave privada en archivos.
 
 ```php
-<?php
-declare(strict_types=1);
-
 use PhpCfdi\Credentials\Credential;
 use PhpCfdi\Finkok\Helpers\CancelSigner;
 use PhpCfdi\Finkok\Services\Cancel\CancelSignatureCommand;

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "eclipxe/cfdiutils": "^2.23.2",
         "phpcfdi/rfc": "^1.1",
         "phpunit/phpunit": "^9.5.10",
-        "symfony/dotenv": "^5.1 || ^6.0"
+        "symfony/dotenv": "^5.1 || ^6.0 || ^7.0"
     },
     "prefer-stable": true,
     "autoload": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,26 @@ Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor e
 
 Estos cambios se aplican y se publican, pero aún no son parte de una versión liberada.
 
+## Versión 0.5.4 2023-06-07
+
+Se actualiza el año de la licencia a 2024.
+
+Se agrega una sección *Capturar conversación HTTP* al archivo `README.md`.
+
+Se actualizan las reglas del estándar de código.
+
+Se permite usar `symfony/dotenv:^7.0` en desarrollo.
+
+Se omite la detección de lenguaje en el directorio `tests/_files`.
+
+Se actualizan los flujos de trabajo de GitHub:
+
+- Se agrega PHP 8.3 a la matriz de pruebas.
+- Se ejecutan los procesos en PHP 8.3.
+- Se usan las acciones de GitHub versión 4.
+
+Se actualizan las herramientas de desarrollo.
+
 ### Mantenimiento 2023-06-20
 
 Se actualiza la FIEL y el CSD del RFC `EKU9003173C9` a versiones recientes, las anteriores habían expirado.

--- a/docs/Ejemplos/CancelacionFirmada.md
+++ b/docs/Ejemplos/CancelacionFirmada.md
@@ -7,9 +7,6 @@ de cancelación del CFDI `11111111-2222-3333-4444-000000000001` del RFC `EKU9003
 ## Ejemplo usando `QuickFinkok`
 
 ```php
-<?php
-declare(strict_types=1);
-
 use PhpCfdi\Credentials\Credential;
 use PhpCfdi\Finkok\FinkokEnvironment;
 use PhpCfdi\Finkok\FinkokSettings;
@@ -45,10 +42,6 @@ composer require phpcfdi/credentials
 ```
 
 ```php
-<?php
-
-declare(strict_types=1);
-
 use PhpCfdi\Credentials\Credential;
 use PhpCfdi\Finkok\Finkok;
 use PhpCfdi\Finkok\FinkokEnvironment;
@@ -79,15 +72,6 @@ composer require phpcfdi/xml-cancelacion
 ```
 
 ```php
-<?php declare(strict_types=1);
-
-use PhpCfdi\Finkok\Finkok;
-use PhpCfdi\Finkok\FinkokEnvironment;
-use PhpCfdi\Finkok\FinkokSettings;
-use PhpCfdi\Finkok\Services\Cancel\CancelSignatureCommand;
-use PhpCfdi\XmlCancelacion\XmlCancelacionHelper;
-use PhpCfdi\XmlCancelacion\Models\CancelDocument;
-
 $cancelXml = (new XmlCancelacionHelper())
     ->setNewCredentials('certificado.cer', 'llave-privada.key.pem', '12345678a')
     ->signCancellation(CancelDocument::newWithErrorsUnrelated('11111111-2222-3333-4444-000000000001'), new DateTimeImmutable());

--- a/docs/Ejemplos/ConsultarEstadoCFDI.md
+++ b/docs/Ejemplos/ConsultarEstadoCFDI.md
@@ -11,9 +11,6 @@ Nota: El servicio `get_sat_status` solo puede obtener datos de CFDI 3.3 y CFDI 3
 Los datos de RFC emisor, receptor, total y UUID se obtienen directamente del CFDI.
 
 ```php
-<?php
-declare(strict_types=1);
-
 use PhpCfdi\Finkok\FinkokEnvironment;
 use PhpCfdi\Finkok\FinkokSettings;
 use PhpCfdi\Finkok\QuickFinkok;
@@ -30,9 +27,6 @@ echo $satStatus->cancellation();    // (vacío)
 ## Usando QuickFinkok con los datos
 
 ```php
-<?php
-declare(strict_types=1);
-
 use PhpCfdi\Finkok\FinkokEnvironment;
 use PhpCfdi\Finkok\FinkokSettings;
 use PhpCfdi\Finkok\QuickFinkok;
@@ -57,9 +51,6 @@ La fachada `Finkok` es un poco más compleja de usar y funciona mejor si se est�
 Para cualquier otro caso se recomienda usar `QuickFinkok`.
 
 ```php
-<?php
-declare(strict_types=1);
-
 use PhpCfdi\Finkok\FinkokEnvironment;
 use PhpCfdi\Finkok\FinkokSettings;
 use PhpCfdi\Finkok\Finkok;

--- a/docs/Ejemplos/Timbrado.md
+++ b/docs/Ejemplos/Timbrado.md
@@ -6,15 +6,13 @@ El resultado del firmado está en `$result` que es de tipo `PhpCfdi\Finkok\Servi
 y se pueden extraer diferentes propiedades de este firmado como el xml firmado o el listado de alertas.
 
 ```php
-<?php
-
-declare(strict_types=1);
-
 use PhpCfdi\Finkok\FinkokEnvironment;
 use PhpCfdi\Finkok\FinkokSettings;
 use PhpCfdi\Finkok\QuickFinkok;
 
-$precfdi = '...';
+/**
+ * @var string $precfdi Para este ejemplo esta variable contiene el CFDI sellado sin el Timbre Fiscal Digital 
+ */
 
 $finkok = new QuickFinkok(new FinkokSettings('finkok-usuario', 'finkok-password', FinkokEnvironment::makeProduction()));
 $result = $finkok->stamp($precfdi);

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="EngineWorks">
-    <description>The EngineWorks (PSR-2 based) coding standard.</description>
+    <description>The EngineWorks (PSR-12 based) coding standard.</description>
 
     <file>src</file>
     <file>tests</file>


### PR DESCRIPTION
Se actualiza el año de la licencia a 2024.

Se agrega una sección *Capturar conversación HTTP* al archivo `README.md`.

Se actualizan las reglas del estándar de código.

Se permite usar `symfony/dotenv:^7.0` en desarrollo.

Se omite la detección de lenguaje en el directorio `tests/_files`.

Se actualizan los flujos de trabajo de GitHub:

- Se agrega PHP 8.3 a la matriz de pruebas.
- Se ejecutan los procesos en PHP 8.3.
- Se usan las acciones de GitHub versión 4.

Se actualizan las herramientas de desarrollo.

Nota: Se libera una nueva versión por el cambio en la documentación y por el cambio en la licencia