### PR TITLE
Compatibilidad con PHP 8.5, dependencias con CVE y json_validate (version 0.6.1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-version: ['8.1', '8.2', '8.3', '8.4']
+        php-version: ['8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpcs" version="^3.13.5" installed="3.13.5" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.13.5" installed="3.13.5" location="./tools/phpcbf" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.89.2" installed="3.89.2" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="^2.1.31" installed="2.1.31" location="./tools/phpstan" copy="false"/>
+  <phar name="phpcs" version="^4.0.1" installed="4.0.1" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^4.0.1" installed="4.0.1" location="./tools/phpcbf" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.92.5" installed="3.92.5" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpstan" version="^2.1.36" installed="2.1.36" location="./tools/phpstan" copy="false"/>
   <phar name="composer-normalize" version="^2.48.2" installed="2.48.2" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -24,7 +24,7 @@ return (new PhpCsFixer\Config())
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'type_declaration_spaces' => true,
-        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays', 'match', 'parameters']],
+        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['array_destructuring', 'arrays', 'match', 'arguments', 'parameters']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
@@ -38,6 +38,7 @@ return (new PhpCsFixer\Config())
         'concat_space' => ['spacing' => 'one'],
         'linebreak_after_opening_tag' => true,
         'fully_qualified_strict_types' => true,
+        'global_namespace_import' => ['import_classes' => true],
         // symfony:risky
         'no_alias_functions' => true,
         'self_accessor' => true,

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 - 2025 PhpCfdi https://www.phpcfdi.com/
+Copyright (c) 2019 - 2026 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "ext-fileinfo": "*",
         "eclipxe/cfdiutils": "^3.0.1",
         "phpcfdi/rfc": "^1.2",
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^10.5.50",
         "rector/rector": "^2.2",
         "symfony/dotenv": "^6.0 || ^7.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "phpcfdi/credentials": "^1.3.0",
         "phpcfdi/xml-cancelacion": "^2.0.5",
         "psr/log": "^3.0",
-        "robrichards/xmlseclibs": "^3.1.3"
+        "robrichards/xmlseclibs": "^3.1.4"
     },
     "require-dev": {
         "ext-fileinfo": "*",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,9 +6,26 @@ Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor e
 
 Estos cambios se aplican y se publican, pero aún no son parte de una versión liberada.
 
+## Versión 0.6.1 2026-02-04
+
+- Se comprueba la compatibilidad con PHP 8.5.
+- Se actualizan dependencias para evitar alertas de seguridad (CVE).
+- Se agrega una validación para prevenir el uso de `json_validate` en versiones de PHP donde no se soporta.
+
+Se hacen varios cambios menores:
+
+- Actualización del estándar de código.
+- Actualización del año de licencia a 2026.
+
+Se hacen varios cambios al entorno de desarrollo:
+
+- Se agrega PHP 8.5 a la matriz de pruebas.
+- Se actualizan las herramientas de desarrollo.
+
 ## Versión 0.6.0 2025-11-08
 
 Esta versión tiene cambios importantes dado que:
+
 - Elimina la compatibilidad con PHP 7.3, PHP 7.4 y PHP 8.0.
 - Agrega la compatibilidad con PHP 8.4.
 

--- a/src/Finkok.php
+++ b/src/Finkok.php
@@ -160,7 +160,7 @@ class Finkok
         $method = static::SERVICES_MAP[$method][2] ?? $method;
         if (! is_callable([$service, $method])) {
             throw new BadMethodCallException(
-                sprintf('The service %s does not have a method %s', $service::class, $method)
+                sprintf('The service %s does not have a method %s', $service::class, $method),
             );
         }
         return $service->{$method}($command);

--- a/src/FinkokSettings.php
+++ b/src/FinkokSettings.php
@@ -75,7 +75,7 @@ class FinkokSettings
         $wsdlLocation = $this->environment()->endpoint($service);
         $credentials = array_merge(
             ('' !== $usernameKey) ? [$usernameKey => $this->username()] : [],
-            ('' !== $passwordKey) ? [$passwordKey => $this->password()] : []
+            ('' !== $passwordKey) ? [$passwordKey => $this->password()] : [],
         );
         return $this->soapFactory()->createSoapCaller($wsdlLocation, $credentials);
     }

--- a/src/Helpers/DocumentSigner.php
+++ b/src/Helpers/DocumentSigner.php
@@ -69,7 +69,7 @@ class DocumentSigner
             $document,
             XMLSecurityDSig::SHA1,
             ['http://www.w3.org/2000/09/xmldsig#enveloped-signature'],
-            ['force_uri' => true]
+            ['force_uri' => true],
         );
 
         $objKey = new XMLSecurityKey(XMLSecurityKey::RSA_SHA1, ['type' => 'private']);

--- a/src/Helpers/JsonDecoderLogger.php
+++ b/src/Helpers/JsonDecoderLogger.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\Finkok\Helpers;
 
+use LogicException;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
 use Stringable;
@@ -100,6 +101,9 @@ final class JsonDecoderLogger extends AbstractLogger implements LoggerInterface
 
     private function jsonDecodeWithValidate(string|Stringable $string): string
     {
+        if (! function_exists('json_validate')) {
+            throw new LogicException('The function \json_validate does not exist.');
+        }
         $string = (string) $string;
         if (json_validate($string)) {
             $this->lastMessageWasJsonValid = true;

--- a/src/Helpers/JsonDecoderLogger.php
+++ b/src/Helpers/JsonDecoderLogger.php
@@ -81,23 +81,28 @@ final class JsonDecoderLogger extends AbstractLogger implements LoggerInterface
     private function jsonDecode(string|Stringable $string): string
     {
         $this->lastMessageWasJsonValid = false;
-        $string = strval($string);
 
         // json_validate and json_decode
-        if ($this->useJsonValidateIfAvailable && function_exists('\json_validate')) {
-            if (\json_validate($string)) {
-                $this->lastMessageWasJsonValid = true;
-                return $this->varDump(json_decode($string));
-            }
-
-            return $string;
+        if ($this->useJsonValidateIfAvailable) {
+            return $this->jsonDecodeWithValidate($string);
         }
 
         // json_decode only
+        $string = (string) $string;
         $decoded = json_decode($string);
         if (JSON_ERROR_NONE === json_last_error()) {
             $this->lastMessageWasJsonValid = true;
             return $this->varDump($decoded);
+        }
+
+        return $string;
+    }
+
+    private function jsonDecodeWithValidate(string|Stringable $string): string
+    {
+        if (json_validate($string)) {
+            $this->lastMessageWasJsonValid = true;
+            return $this->varDump(json_decode($string));
         }
 
         return $string;

--- a/src/Helpers/JsonDecoderLogger.php
+++ b/src/Helpers/JsonDecoderLogger.php
@@ -100,6 +100,7 @@ final class JsonDecoderLogger extends AbstractLogger implements LoggerInterface
 
     private function jsonDecodeWithValidate(string|Stringable $string): string
     {
+        $string = (string) $string;
         if (json_validate($string)) {
             $this->lastMessageWasJsonValid = true;
             return $this->varDump(json_decode($string));

--- a/src/QuickFinkok.php
+++ b/src/QuickFinkok.php
@@ -471,7 +471,7 @@ class QuickFinkok
         if (! $documents->success()) {
             return Manifest\SignContractsResult::createFromData(
                 false,
-                sprintf('Unable to get contracts: %s', $documents->error() ?: '(no error)')
+                sprintf('Unable to get contracts: %s', $documents->error() ?: '(no error)'),
             );
         }
         $privacy = (new Helpers\DocumentSigner($rfc, $signedOn, $documents->privacy()))->signUsingCredential($fiel);

--- a/src/Services/AbstractResult.php
+++ b/src/Services/AbstractResult.php
@@ -19,7 +19,7 @@ abstract class AbstractResult
         $root = $this->findInDescendent($this->data, ...$meanLocation);
         if (! $root instanceof stdClass) {
             throw new InvalidArgumentException(
-                sprintf('Unable to find mean object at /%s', implode('/', $meanLocation))
+                sprintf('Unable to find mean object at /%s', implode('/', $meanLocation)),
             );
         }
         $this->root = $root;

--- a/src/Services/Cancel/AcceptRejectSignatureResult.php
+++ b/src/Services/Cancel/AcceptRejectSignatureResult.php
@@ -26,7 +26,7 @@ class AcceptRejectSignatureResult extends AbstractResult
             array_merge(
                 $this->filterArrayOfStdClass($aceptacion),
                 $this->filterArrayOfStdClass($rechazo),
-            )
+            ),
         );
         $this->error = $this->get('error');
     }

--- a/src/Services/Cancel/AcceptRejectUuidList.php
+++ b/src/Services/Cancel/AcceptRejectUuidList.php
@@ -53,7 +53,7 @@ class AcceptRejectUuidList extends AbstractCollection
         return new AcceptRejectUuidItem(
             $this->filterString($source->uuid ?? ''),
             new AcceptRejectUuidStatus($this->filterString($source->status ?? '0')),
-            $answer
+            $answer,
         );
     }
 }

--- a/src/Services/Cancel/RelatedItems.php
+++ b/src/Services/Cancel/RelatedItems.php
@@ -20,7 +20,7 @@ class RelatedItems extends AbstractCollection
         return new RelatedItem(
             $this->filterString($content->{'uuid'} ?? ''),
             $this->filterString($content->{'emisor'} ?? ''),
-            $this->filterString($content->{'receptor'} ?? '')
+            $this->filterString($content->{'receptor'} ?? ''),
         );
     }
 }

--- a/src/Services/Registration/AddService.php
+++ b/src/Services/Registration/AddService.php
@@ -23,7 +23,7 @@ class AddService
         $soapCaller = $this->settings()->createCallerForService(
             Services::registration(),
             'reseller_username',
-            'reseller_password'
+            'reseller_password',
         );
         $rawResponse = $soapCaller->call('add', array_filter([
             'taxpayer_id' => $command->rfc(),

--- a/src/Services/Registration/EditService.php
+++ b/src/Services/Registration/EditService.php
@@ -23,7 +23,7 @@ class EditService
         $soapCaller = $this->settings()->createCallerForService(
             Services::registration(),
             'reseller_username',
-            'reseller_password'
+            'reseller_password',
         );
         $rawResponse = $soapCaller->call('edit', array_filter([
             'taxpayer_id' => $command->rfc(),

--- a/src/Services/Registration/ObtainCustomersService.php
+++ b/src/Services/Registration/ObtainCustomersService.php
@@ -38,7 +38,7 @@ class ObtainCustomersService
         $soapCaller = $this->settings()->createCallerForService(
             Services::registration(),
             'username',
-            'password'
+            'password',
         );
         $rawResponse = $soapCaller->call('customers', [
             'page' => $command->page(),

--- a/src/Services/Registration/ObtainService.php
+++ b/src/Services/Registration/ObtainService.php
@@ -23,7 +23,7 @@ class ObtainService
         $soapCaller = $this->settings()->createCallerForService(
             Services::registration(),
             'reseller_username',
-            'reseller_password'
+            'reseller_password',
         );
         $rawResponse = $soapCaller->call('get', [
             'taxpayer_id' => $command->rfc(),

--- a/src/Services/Utilities/ReportCreditResult.php
+++ b/src/Services/Utilities/ReportCreditResult.php
@@ -20,7 +20,7 @@ class ReportCreditResult extends AbstractResult
         parent::__construct($data, 'report_creditResult');
 
         $items = $this->filterArrayOfStdClass(
-            $this->findInDescendent($data, 'report_creditResult', 'result', 'ReportTotalCredit')
+            $this->findInDescendent($data, 'report_creditResult', 'result', 'ReportTotalCredit'),
         );
         foreach ($items as $item) {
             $this->items[] = [

--- a/src/Services/Utilities/ReportTotalCommand.php
+++ b/src/Services/Utilities/ReportTotalCommand.php
@@ -56,7 +56,7 @@ class ReportTotalCommand
 
         if ($this->startPeriod > $this->endPeriod) {
             throw new LogicException(
-                sprintf('Start period %s cannot be greater than end period %s', $this->startPeriod, $this->endPeriod)
+                sprintf('Start period %s cannot be greater than end period %s', $this->startPeriod, $this->endPeriod),
             );
         }
 

--- a/src/Services/Utilities/ReportUuidResult.php
+++ b/src/Services/Utilities/ReportUuidResult.php
@@ -20,7 +20,7 @@ class ReportUuidResult extends AbstractResult
         parent::__construct($data, 'report_uuidResult');
 
         $items = $this->filterArrayOfStdClass(
-            $this->findInDescendent($data, 'report_uuidResult', 'invoices', 'ReportUUID')
+            $this->findInDescendent($data, 'report_uuidResult', 'invoices', 'ReportUUID'),
         );
         foreach ($items as $item) {
             $this->items[] = [

--- a/src/SoapCaller.php
+++ b/src/SoapCaller.php
@@ -60,9 +60,9 @@ class SoapCaller implements LoggerAwareInterface
                 array_merge(
                     ['method' => $methodName, 'parameters' => $finalParameters],
                     $this->extractSoapClientTrace($soap),
-                    ['exception' => ($exception instanceof JsonSerializable) ? $exception : print_r($exception, true)]
+                    ['exception' => ($exception instanceof JsonSerializable) ? $exception : print_r($exception, true)],
                 ),
-                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES,
             )));
             throw new RuntimeException(sprintf('Fail soap call to %s', $methodName), previous: $exception);
         }

--- a/tests/Factories/RandomPreCfdi.php
+++ b/tests/Factories/RandomPreCfdi.php
@@ -20,7 +20,7 @@ final class RandomPreCfdi
         return new PreCfdiCreatorHelper(
             TestCase::filePath('certs/EKU9003173C9.cer'),
             TestCase::filePath('certs/EKU9003173C9.key.pem'),
-            trim(TestCase::fileContentPath('certs/EKU9003173C9.password.bin'))
+            trim(TestCase::fileContentPath('certs/EKU9003173C9.password.bin')),
         );
     }
 

--- a/tests/Factories/RandomPreCfdiRetention.php
+++ b/tests/Factories/RandomPreCfdiRetention.php
@@ -22,7 +22,7 @@ final class RandomPreCfdiRetention
             'EKU9003173C9',
             'ESCUELA KEMPER URGATE',
             '52000',
-            '601'
+            '601',
         );
         $helper->setCveReten('14');
         $helper->setInvoiceDate(new DateTimeImmutable());
@@ -57,7 +57,7 @@ final class RandomPreCfdiRetention
                 'MontISRAcredNal' => '0',
                 'MontDivAcumNal' => '0',
                 'MontDivAcumExt' => '0',
-            ])
+            ]),
         );
 
         $preCfdi = $helper->signPreCfdi($creator);
@@ -70,8 +70,8 @@ final class RandomPreCfdiRetention
                 PHP_EOL,
                 implode(PHP_EOL, array_map(fn (Assert $assert): string => rtrim(
                     sprintf('%s - %s: %s', $assert->getCode(), $assert->getTitle(), $assert->getExplanation()),
-                    ' :'
-                ), $assets->errors()))
+                    ' :',
+                ), $assets->errors())),
             ));
         }
 

--- a/tests/Integration/Services/Cancel/CancelServicesTest.php
+++ b/tests/Integration/Services/Cancel/CancelServicesTest.php
@@ -25,7 +25,7 @@ final class CancelServicesTest extends IntegrationTestCase
         // check that it has a correct status
         $beforeCancelStatus = $this->checkCanGetSatStatusOrFail(
             $cfdi->xml(),
-            'Cannot assert cfdi before cancel status is not: No Encontrado'
+            'Cannot assert cfdi before cancel status is not: No Encontrado',
         );
         $this->assertSame('Vigente', $beforeCancelStatus->cfdi());
         $this->assertStringStartsWith('Cancelable ', $beforeCancelStatus->cancellable());
@@ -40,7 +40,7 @@ final class CancelServicesTest extends IntegrationTestCase
         do {
             // build command on every request
             $command = $this->createCancelSignatureCommandFromDocument(
-                CancelDocument::newWithErrorsUnrelated($cfdi->uuid())
+                CancelDocument::newWithErrorsUnrelated($cfdi->uuid()),
             );
             // perform cancel
             $result = $service->cancelSignature($command);
@@ -88,7 +88,7 @@ final class CancelServicesTest extends IntegrationTestCase
         $this->assertSame(
             '201', // 201 - Petición de cancelación realizada exitosamente
             $document->documentStatus(),
-            'SAT did not return 201 EstatusUUID on CancelSignature, is the service down?'
+            'SAT did not return 201 EstatusUUID on CancelSignature, is the service down?',
         );
         // check result properties
         $this->assertNotEmpty($result->voucher(), 'Finkok did not return voucher (Acuse) on CancelSignature');
@@ -97,17 +97,17 @@ final class CancelServicesTest extends IntegrationTestCase
 
         // Consume GetReceiptService and assert that the response is the same (as XML and as string)
         $receipt = (new GetReceiptService($settings))->download(
-            new GetReceiptCommand('EKU9003173C9', $cfdi->uuid(), ReceiptType::cancellation())
+            new GetReceiptCommand('EKU9003173C9', $cfdi->uuid(), ReceiptType::cancellation()),
         );
         $this->assertXmlStringEqualsXmlString(
             $result->voucher(),
             $receipt->receipt(),
-            'El acuse que proviene del método get_receipt no coincide con el acuse de la cancelación'
+            'El acuse que proviene del método get_receipt no coincide con el acuse de la cancelación',
         );
         $this->assertSame(
             $result->voucher(),
             $receipt->receipt(),
-            'El acuse que proviene del método get_receipt no es exactamente el mismo que el acuse de la cancelación'
+            'El acuse que proviene del método get_receipt no es exactamente el mismo que el acuse de la cancelación',
         );
     }
 
@@ -129,7 +129,7 @@ final class CancelServicesTest extends IntegrationTestCase
         // check that it has a correct status
         $beforeCancelStatus = $this->checkCanGetSatStatusOrFail(
             $cfdiXml,
-            'Cannot assert cfdi before cancel status is not: No Encontrado'
+            'Cannot assert cfdi before cancel status is not: No Encontrado',
         );
 
         $this->assertSame('Vigente', $beforeCancelStatus->cfdi());
@@ -139,7 +139,7 @@ final class CancelServicesTest extends IntegrationTestCase
         $service = new CancelSignatureService($settings);
 
         $command = $this->createCancelSignatureCommandFromDocument(
-            CancelDocument::newWithErrorsUnrelated($cfdiUuid)
+            CancelDocument::newWithErrorsUnrelated($cfdiUuid),
         );
 
         // perform cancel
@@ -150,7 +150,7 @@ final class CancelServicesTest extends IntegrationTestCase
         $this->assertSame(
             '201', // 201 - Petición de cancelación realizada exitosamente
             $document->documentStatus(),
-            'SAT did not return 201 EstatusUUID on CancelSignature, is the service down?'
+            'SAT did not return 201 EstatusUUID on CancelSignature, is the service down?',
         );
 
         // check result properties
@@ -160,17 +160,17 @@ final class CancelServicesTest extends IntegrationTestCase
 
         // Consume GetReceiptService and assert that the response is the same (as XML and as string)
         $receipt = (new GetReceiptService($settings))->download(
-            new GetReceiptCommand('EKU9003173C9', $cfdiUuid, ReceiptType::cancellation())
+            new GetReceiptCommand('EKU9003173C9', $cfdiUuid, ReceiptType::cancellation()),
         );
         $this->assertXmlStringEqualsXmlString(
             $result->voucher(),
             $receipt->receipt(),
-            'El acuse que proviene del método get_receipt no coincide con el acuse de la cancelación'
+            'El acuse que proviene del método get_receipt no coincide con el acuse de la cancelación',
         );
         $this->assertSame(
             $result->voucher(),
             $receipt->receipt(),
-            'El acuse que proviene del método get_receipt no es exactamente el mismo que el acuse de la cancelación'
+            'El acuse que proviene del método get_receipt no es exactamente el mismo que el acuse de la cancelación',
         );
     }
 }

--- a/tests/Integration/Services/Cancel/CancelSignatureServiceTest.php
+++ b/tests/Integration/Services/Cancel/CancelSignatureServiceTest.php
@@ -22,7 +22,7 @@ final class CancelSignatureServiceTest extends IntegrationTestCase
         $expectedStatusCode = sprintf('UUID: %s No Encontrado', $uuid);
 
         $command = $this->createCancelSignatureCommandFromDocument(
-            CancelDocument::newWithErrorsUnrelated($uuid)
+            CancelDocument::newWithErrorsUnrelated($uuid),
         );
         $service = $this->createService();
         $result = $service->cancelSignature($command);

--- a/tests/Integration/Services/Cancel/GetReceiptServiceTest.php
+++ b/tests/Integration/Services/Cancel/GetReceiptServiceTest.php
@@ -24,7 +24,7 @@ final class GetReceiptServiceTest extends IntegrationTestCase
         $command = new GetReceiptCommand(
             'EKU9003173C9',
             '12345678-1234-1234-1234-123456789012',
-            ReceiptType::cancellation()
+            ReceiptType::cancellation(),
         );
 
         $result = $service->download($command);

--- a/tests/Integration/Services/Cancel/GetSatStatusServiceTest.php
+++ b/tests/Integration/Services/Cancel/GetSatStatusServiceTest.php
@@ -24,7 +24,7 @@ final class GetSatStatusServiceTest extends IntegrationTestCase
             'EKU9003173C9',
             'LAN7008173R5',
             '12345678-1234-1234-1234-123456789012',
-            '12345.67'
+            '12345.67',
         );
 
         $result = $service->query($command);

--- a/tests/Integration/Services/Manifest/GetContractsServiceTest.php
+++ b/tests/Integration/Services/Manifest/GetContractsServiceTest.php
@@ -23,7 +23,7 @@ final class GetContractsServiceTest extends IntegrationTestCase
             'Empresa Conocida SA de CV',
             'Cuauhtémoc #123, Colonia Centro, Villahermosa, Tabasco. CP 86000',
             'legal@empresa-conocida.mx',
-            $this->getenv('FINKOK_SNID')
+            $this->getenv('FINKOK_SNID'),
         );
 
         $service = $this->createService();

--- a/tests/Integration/Services/Manifest/GetSignedContractsServiceTest.php
+++ b/tests/Integration/Services/Manifest/GetSignedContractsServiceTest.php
@@ -36,7 +36,7 @@ final class GetSignedContractsServiceTest extends IntegrationTestCase
         $command = new GetSignedContractsCommand(
             $this->getenv('FINKOK_SNID'),
             'EKU9003173C9',
-            $format
+            $format,
         );
 
         $service = $this->createService();

--- a/tests/Integration/Services/Manifest/SignContractsServiceTest.php
+++ b/tests/Integration/Services/Manifest/SignContractsServiceTest.php
@@ -28,7 +28,7 @@ final class SignContractsServiceTest extends IntegrationTestCase
             'Empresa Conocida SA de CV',
             'Cuauhtémoc #123, Colonia Centro, Villahermosa, Tabasco. CP 86000',
             'legal@empresa-conocida.mx',
-            $this->getenv('FINKOK_SNID')
+            $this->getenv('FINKOK_SNID'),
         );
 
         $srvGetContracts = new GetContractsService($settings);
@@ -44,7 +44,7 @@ final class SignContractsServiceTest extends IntegrationTestCase
         $cmdSignContracts = new SignContractsCommand(
             $this->getenv('FINKOK_SNID'),
             $privacyDocument->sign($certificateFile, $privateKeyFile, $passPhrase),
-            $contractDocument->sign($certificateFile, $privateKeyFile, $passPhrase)
+            $contractDocument->sign($certificateFile, $privateKeyFile, $passPhrase),
         );
 
         $srvSignContracts = new SignContractsService($settings);

--- a/tests/Integration/Services/Registration/AssignServiceTest.php
+++ b/tests/Integration/Services/Registration/AssignServiceTest.php
@@ -36,7 +36,7 @@ final class AssignServiceTest extends RegistrationIntegrationTestCase
             $switchService = new SwitchService($this->staticSettings());
             $this->assertTrue(
                 $switchService->switch(new SwitchCommand($rfc, CustomerType::ondemand()))->success(),
-                'Unable to change the customer type to on-demand'
+                'Unable to change the customer type to on-demand',
             );
             $customer = $this->findCustomerOrFail($rfc);
         }
@@ -53,7 +53,7 @@ final class AssignServiceTest extends RegistrationIntegrationTestCase
             $switchService = new SwitchService($this->staticSettings());
             $this->assertTrue(
                 $switchService->switch(new SwitchCommand($rfc, CustomerType::prepaid()))->success(),
-                'Unable to change the customer type to prepaid'
+                'Unable to change the customer type to prepaid',
             );
             $customer = $this->findCustomerOrFail($rfc);
         }
@@ -63,7 +63,7 @@ final class AssignServiceTest extends RegistrationIntegrationTestCase
         if ($customer->credit() > 0) {
             $this->assertTrue(
                 $service->assign(new AssignCommand($rfc, -1 * $customer->credit()))->success(),
-                'Unable to set current credits to zero'
+                'Unable to set current credits to zero',
             );
             $customer = $this->findCustomerOrFail($rfc);
         }
@@ -102,7 +102,7 @@ final class AssignServiceTest extends RegistrationIntegrationTestCase
         $this->assertSame(3, $assignResult->credit(), 'Credit must contain previous credits');
         $this->assertSame(
             'The number of credits to decrease is greater than the number of current credits.',
-            $assignResult->message()
+            $assignResult->message(),
         );
     }
 

--- a/tests/Integration/Services/Registration/EditServiceTest.php
+++ b/tests/Integration/Services/Registration/EditServiceTest.php
@@ -29,7 +29,7 @@ final class EditServiceTest extends RegistrationIntegrationTestCase
         $this->assertSame('Account was Suspended successfully', $editToSuspended->message());
         $this->assertTrue(
             $this->findCustomerOrFail($rfc)->status()->isSuspended(),
-            "Customer $rfc was not changed to Suspended"
+            "Customer $rfc was not changed to Suspended",
         );
 
         $editToActive = $service->edit(new EditCommand($rfc, CustomerStatus::active()));
@@ -37,7 +37,7 @@ final class EditServiceTest extends RegistrationIntegrationTestCase
         $this->assertSame('Account was Activated successfully', $editToActive->message());
         $this->assertTrue(
             $this->findCustomerOrFail($rfc)->status()->isActive(),
-            "Customer $rfc was not changed to Active"
+            "Customer $rfc was not changed to Active",
         );
     }
 
@@ -55,7 +55,7 @@ final class EditServiceTest extends RegistrationIntegrationTestCase
         $this->assertSame('Account was Activated successfully', $editToActive->message());
         $this->assertTrue(
             $this->findCustomerOrFail($rfc)->status()->isActive(),
-            "Customer $rfc was not changed to Active"
+            "Customer $rfc was not changed to Active",
         );
     }
 

--- a/tests/Integration/Services/Registration/SwitchServiceTest.php
+++ b/tests/Integration/Services/Registration/SwitchServiceTest.php
@@ -27,14 +27,14 @@ final class SwitchServiceTest extends RegistrationIntegrationTestCase
         $this->assertEquals(
             $changeTo,
             $this->findCustomerOrFail($rfc)->customerType(),
-            'Expected to change user type to a different one'
+            'Expected to change user type to a different one',
         );
 
         $service->switch(new SwitchCommand($rfc, $currentType));
         $this->assertEquals(
             $currentType,
             $this->findCustomerOrFail($rfc)->customerType(),
-            'Expected to change customer type to original'
+            'Expected to change customer type to original',
         );
     }
 

--- a/tests/Integration/Services/Retentions/CancelSignatureServiceTest.php
+++ b/tests/Integration/Services/Retentions/CancelSignatureServiceTest.php
@@ -28,7 +28,7 @@ final class CancelSignatureServiceTest extends RetentionsTestCase
 
         $result = $this->quickFinkok->retentionCancel(
             $this->createCsdCredential(),
-            CancelDocument::newWithErrorsUnrelated($uuid)
+            CancelDocument::newWithErrorsUnrelated($uuid),
         );
 
         $this->assertSame($expectedStatusCode, $result->statusCode());
@@ -48,7 +48,7 @@ final class CancelSignatureServiceTest extends RetentionsTestCase
         while (true) {
             $result = $this->quickFinkok->retentionCancel(
                 $cancelCredential,
-                CancelDocument::newWithErrorsUnrelated($uuid)
+                CancelDocument::newWithErrorsUnrelated($uuid),
             );
             $document = $result->documents()->first();
 
@@ -78,7 +78,7 @@ final class CancelSignatureServiceTest extends RetentionsTestCase
         $this->assertNotEmpty($result->voucher(), 'Expected to receive an Acuse, but it was empty');
         $this->assertEmpty(
             $result->statusCode(),
-            "CodEstatus (value: {$result->statusCode()}) should have content only when failing"
+            "CodEstatus (value: {$result->statusCode()}) should have content only when failing",
         );
         $this->assertSame($uuid, $document->uuid());
         $this->assertSame('1201', $document->documentStatus());

--- a/tests/Integration/Services/Retentions/RetentionsUsingExistentRetentionTest.php
+++ b/tests/Integration/Services/Retentions/RetentionsUsingExistentRetentionTest.php
@@ -41,7 +41,7 @@ final class RetentionsUsingExistentRetentionTest extends RetentionsTestCase
         $this->quickFinkok = new QuickFinkok($this->createSettingsFromEnvironment());
         $this->assertNotEmpty(
             $this->currentRetentionsStampResult()->uuid(),
-            'To run this test there must be an already stamped retention precfdi'
+            'To run this test there must be an already stamped retention precfdi',
         );
     }
 
@@ -68,12 +68,12 @@ final class RetentionsUsingExistentRetentionTest extends RetentionsTestCase
         $this->assertXmlStringEqualsXmlString(
             $currentResult->xml(),
             $stampedResult->xml(),
-            'Created and downloaded RET must be XML equal'
+            'Created and downloaded RET must be XML equal',
         );
         $this->assertSame(
             $currentResult->xml(),
             $stampedResult->xml(),
-            'Created and downloaded RET must be identical'
+            'Created and downloaded RET must be identical',
         );
     }
 
@@ -86,12 +86,12 @@ final class RetentionsUsingExistentRetentionTest extends RetentionsTestCase
         $this->assertXmlStringEqualsXmlString(
             $currentResult->xml(),
             $downloadResult->xml(),
-            'Created and downloaded RET must be XML equal'
+            'Created and downloaded RET must be XML equal',
         );
         $this->assertSame(
             $currentResult->xml(),
             $downloadResult->xml(),
-            'Created and downloaded RET must be identical'
+            'Created and downloaded RET must be identical',
         );
     }
 }

--- a/tests/Integration/Services/Stamping/QuickStampServiceTest.php
+++ b/tests/Integration/Services/Stamping/QuickStampServiceTest.php
@@ -37,7 +37,7 @@ final class QuickStampServiceTest extends IntegrationTestCase
         $secondResult = $service->quickstamp($this->currentStampingCommand());
         $this->assertNotNull(
             $secondResult->alerts()->findByErrorCode('307'),
-            'Finkok must alert that it was previously stamped'
+            'Finkok must alert that it was previously stamped',
         );
     }
 
@@ -51,7 +51,7 @@ final class QuickStampServiceTest extends IntegrationTestCase
         $secondResult = $service->quickstamp($currentCfdiStampCommand);
         $this->assertNotNull(
             $secondResult->alerts()->findByErrorCode('707'),
-            'Finkok must alert that it contains and existing TFD'
+            'Finkok must alert that it contains and existing TFD',
         );
     }
 

--- a/tests/Integration/Services/Stamping/StampServiceTest.php
+++ b/tests/Integration/Services/Stamping/StampServiceTest.php
@@ -36,13 +36,13 @@ final class StampServiceTest extends IntegrationTestCase
         $secondResult = $this->createService()->stamp($this->currentStampingCommand());
         $this->assertNotNull(
             $secondResult->alerts()->findByErrorCode('307'),
-            'Finkok must alert that it was previously stamped'
+            'Finkok must alert that it was previously stamped',
         );
 
         $this->assertSame(
             $firstResult->uuid(),
             $secondResult->uuid(),
-            'Finkok does not return the same UUID for duplicated stamp call'
+            'Finkok does not return the same UUID for duplicated stamp call',
         );
     }
 
@@ -56,7 +56,7 @@ final class StampServiceTest extends IntegrationTestCase
         $secondResult = $service->stamp($currentCfdiStampCommand);
         $this->assertNotNull(
             $secondResult->alerts()->findByErrorCode('707'),
-            'Finkok must alert that it contains and existing TFD'
+            'Finkok must alert that it contains and existing TFD',
         );
     }
 
@@ -82,7 +82,7 @@ final class StampServiceTest extends IntegrationTestCase
     {
         $description = sprintf(
             'Mousepad con leyenda «%s es un texto XML válido»',
-            htmlentities($descriptionPart, ENT_XML1)
+            htmlentities($descriptionPart, ENT_XML1),
         );
         $expectedXmlEncodedText = htmlentities($description, ENT_XML1);
 

--- a/tests/Integration/Services/Stamping/StampedServiceTest.php
+++ b/tests/Integration/Services/Stamping/StampedServiceTest.php
@@ -39,7 +39,7 @@ final class StampedServiceTest extends IntegrationTestCase
         $this->assertSame(
             $previousStamp->uuid(),
             $result->uuid(),
-            'Finkok does not return the same UUID for recently created stamp using stamped'
+            'Finkok does not return the same UUID for recently created stamp using stamped',
         );
     }
 }

--- a/tests/Integration/Services/Utilities/DatetimeServiceTest.php
+++ b/tests/Integration/Services/Utilities/DatetimeServiceTest.php
@@ -24,7 +24,7 @@ final class DatetimeServiceTest extends IntegrationTestCase
         $this->assertGreaterThanOrEqual(
             3600,
             $tsCancun - $tsTijuana + 1,
-            'Cancún and Tijuana must always have a different time at least for 1 hour'
+            'Cancún and Tijuana must always have a different time at least for 1 hour',
         );
     }
 
@@ -45,7 +45,7 @@ final class DatetimeServiceTest extends IntegrationTestCase
         $currentTime = time();
         $this->assertThat($converted, $this->logicalAnd(
             $this->greaterThanOrEqual($currentTime - $margin),
-            $this->lessThanOrEqual($currentTime + $margin)
+            $this->lessThanOrEqual($currentTime + $margin),
         ), sprintf('Finkok date %s is not %s +/- %d second', date('c', $converted), date('c', $currentTime), $margin));
     }
 
@@ -54,7 +54,7 @@ final class DatetimeServiceTest extends IntegrationTestCase
         $settings = new FinkokSettings(
             'foo-bar-baz',
             'foo-bar-baz',
-            FinkokEnvironment::makeDevelopment()
+            FinkokEnvironment::makeDevelopment(),
         );
         $service = new DatetimeService($settings);
         $result = $service->datetime(new DatetimeCommand(''));

--- a/tests/Integration/Services/Utilities/DownloadXmlServiceTest.php
+++ b/tests/Integration/Services/Utilities/DownloadXmlServiceTest.php
@@ -37,7 +37,7 @@ final class DownloadXmlServiceTest extends IntegrationTestCase
         $this->assertXmlStringEqualsXmlString(
             $previousStamp->xml(),
             $result->xml(),
-            'Finkok does not return equal XML for recently created stamp using get_xml'
+            'Finkok does not return equal XML for recently created stamp using get_xml',
         );
         $this->assertEmpty($result->error(), 'Finkok must not return an error');
         // see finkok ticket: https://support.finkok.com/support/tickets/41438
@@ -45,7 +45,7 @@ final class DownloadXmlServiceTest extends IntegrationTestCase
         $this->assertSame(
             $previousStamp->xml(),
             $result->xml(),
-            'Finkok does not return exactly the same XML for recently created stamp using get_xml'
+            'Finkok does not return exactly the same XML for recently created stamp using get_xml',
         );
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,7 +19,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $settings = new FinkokSettings(
             $this->getenv('FINKOK_USERNAME') ?: 'username-non-set',
             $this->getenv('FINKOK_PASSWORD') ?: 'password-non-set',
-            FinkokEnvironment::makeDevelopment()
+            FinkokEnvironment::makeDevelopment(),
         );
         if (null !== $soapFactory) {
             $settings->changeSoapFactory($soapFactory);
@@ -31,7 +31,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
                 __DIR__,
                 (new DateTimeImmutable())->format('YmdHis.u'),
                 $this->name(),
-                uniqid()
+                uniqid(),
             );
             $logger = new JsonDecoderLogger(new FileLogger($loggerOutputFile));
             $settings->soapFactory()->setLogger($logger);

--- a/tests/Unit/FinkokTest.php
+++ b/tests/Unit/FinkokTest.php
@@ -47,7 +47,7 @@ final class FinkokTest extends TestCase
         $finkok->expects($this->once())->method('executeService')->with(
             $this->equalTo('stamp'),
             $this->isInstanceOf(StampService::class),
-            $this->isInstanceOf(StampingCommand::class)
+            $this->isInstanceOf(StampingCommand::class),
         )->willReturn($result);
 
         $this->assertSame($result, $finkok->stamp($command));
@@ -74,7 +74,7 @@ final class FinkokTest extends TestCase
         $this->expectExceptionMessage(
             'Call PhpCfdi\Finkok\Finkok::getContracts'
             . ' expect PhpCfdi\Finkok\Services\Manifest\GetContractsCommand'
-            . ' but received ' . $command::class
+            . ' but received ' . $command::class,
         );
         $finkok->{'getContracts'}($command);  /** @phpstan-ignore-line argument.type */
     }
@@ -154,7 +154,7 @@ final class FinkokTest extends TestCase
             $service = $exposer->exposeCreateService($methodName);
             $this->assertTrue(
                 is_callable([$service, $finalMethodName]),
-                "The finalMethodName $methodName was not found"
+                "The finalMethodName $methodName was not found",
             );
         }
     }

--- a/tests/Unit/Helpers/JsonDecoderLoggerTest.php
+++ b/tests/Unit/Helpers/JsonDecoderLoggerTest.php
@@ -97,9 +97,9 @@ final class JsonDecoderLoggerTest extends TestCase
                 function ($message) use ($matcher, $expectedParameters): bool {
                     $this->assertSame($expectedParameters[$matcher->numberOfInvocations() - 1], $message);
                     return true;
-                }
+                },
             ),
-            []
+            [],
         );
 
         $decoder = new JsonDecoderLogger($logger);

--- a/tests/Unit/QuickFinkokTest.php
+++ b/tests/Unit/QuickFinkokTest.php
@@ -45,7 +45,7 @@ final class QuickFinkokTest extends TestCase
         $this->assertSame(
             array_merge($lastCall->latestCallParameters, $expectedParameters),
             $lastCall->latestCallParameters,
-            'Expected parameters does not match'
+            'Expected parameters does not match',
         );
     }
 
@@ -231,7 +231,7 @@ final class QuickFinkokTest extends TestCase
         $result = $finkok->answerAcceptRejectCancellation(
             $this->createCsdCredential(),
             'x-uuid',
-            CancelAnswer::reject()
+            CancelAnswer::reject(),
         );
 
         $this->performTestOnLatestCall('accept_reject_signature');
@@ -465,14 +465,14 @@ final class QuickFinkokTest extends TestCase
                 $this->identicalTo($fiel->rfc()),
                 $this->identicalTo($fiel->legalName()),
                 $this->identicalTo('x-address'),
-                $this->identicalTo('x-email')
+                $this->identicalTo('x-email'),
             );
         $finkok->expects($this->once())
             ->method('customerSendContracts')->willReturn($signContractsResult)
             ->with(
                 $this->identicalTo('x-snid'),
                 $this->stringContains($getContractsResult->privacy()),
-                $this->stringContains($getContractsResult->contract())
+                $this->stringContains($getContractsResult->contract()),
             );
 
         $signedOn = new DateTimeImmutable('2019-01-13 14:15:16');

--- a/tests/create-pem-files.php
+++ b/tests/create-pem-files.php
@@ -30,12 +30,12 @@ $converter = function (string $cerFile, string $keyFile, string $passPhrase): vo
 $converter(
     TestCase::filePath('certs/EKU9003173C9.cer'),
     TestCase::filePath('certs/EKU9003173C9.key'),
-    trim(TestCase::fileContentPath('certs/EKU9003173C9.password.bin'))
+    trim(TestCase::fileContentPath('certs/EKU9003173C9.password.bin')),
 );
 
 // FIEL
 $converter(
     TestCase::filePath('fiel/EKU9003173C9.cer'),
     TestCase::filePath('fiel/EKU9003173C9.key'),
-    trim(TestCase::fileContentPath('fiel/EKU9003173C9.password.bin'))
+    trim(TestCase::fileContentPath('fiel/EKU9003173C9.password.bin')),
 );

--- a/tests/stamp-precfdi-devenv.php
+++ b/tests/stamp-precfdi-devenv.php
@@ -39,7 +39,7 @@ exit(call_user_func(new class ($argv[0] ?? '') {
             $settings = new FinkokSettings(
                 TestCase::getenv('FINKOK_USERNAME') ?: 'username-non-set',
                 TestCase::getenv('FINKOK_PASSWORD') ?: 'password-non-set',
-                FinkokEnvironment::makeDevelopment()
+                FinkokEnvironment::makeDevelopment(),
             );
             if ($debug) {
                 $settings->soapFactory()->setLogger(new JsonDecoderLogger(new FileLogger()));
@@ -61,7 +61,7 @@ exit(call_user_func(new class ($argv[0] ?? '') {
             file_put_contents(
                 'php://stderr',
                 sprintf("%s: %s\n", $exception::class, $exception->getMessage()),
-                FILE_APPEND
+                FILE_APPEND,
             );
             return (int) $exception->getCode() ?: 1;
         }


### PR DESCRIPTION
- Se comprueba la compatibilidad con PHP 8.5.
- Se actualizan dependencias para evitar alertas de seguridad (CVE).
- Se agrega una validación para prevenir el uso de `json_validate` en versiones de PHP donde no se soporta.

Se hacen varios cambios menores:

- Actualización del estándar de código.
- Actualización del año de licencia a 2026.

Se hacen varios cambios al entorno de desarrollo:

- Se agrega PHP 8.5 a la matriz de pruebas.
- Se actualizan las herramientas de desarrollo.
